### PR TITLE
Fix Missing Bold Print Fonts

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,4 +1,7 @@
 {
+  "1.4.2": {
+    "description": "Fixes missing bold fonts in Chrome print view."
+  },
   "1.4.1": {
     "description": "Fixes buggy system movement.",
     "changes": [

--- a/src/components/printable-sector/printable-sector.js
+++ b/src/components/printable-sector/printable-sector.js
@@ -94,7 +94,7 @@ const renderSystems = systems =>
 
 export default function PrintableSector({ printable, systems }) {
   return (
-    <div>
+    <div className="PrintableSector">
       <div className="PrintableSector-Container">
         <HexMap hexes={printable.hexes} viewbox={printable.viewbox} />
       </div>

--- a/src/components/printable-sector/style.scss
+++ b/src/components/printable-sector/style.scss
@@ -1,4 +1,8 @@
-@import "styles/theme";
+@import 'styles/theme';
+
+.PrintableSector * {
+  font-family: 'Helvetica', sans-serif !important;
+}
 
 .PrintableSector-Container {
   display: none;


### PR DESCRIPTION
## Description

Using bold google fonts in the chrome print view doesn't work for some reason. You'd think that would work, right? 

Anyway... the printable will use Helvetica now.

Fixes #16 