### PR TITLE
Short Circuit Hex Generation

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,4 +1,11 @@
 {
+  "1.4.3": {
+    "description": "Browser doesn't hang if viewing site in a small viewport.",
+    "changes": [
+      "An error message will appear when viewport is too small rather than rendering all the hexagons",
+      "Will stop rendering hexagons if the total number reaches 800 or a viewport dimension is less than 200 pixels"
+    ]
+  },
   "1.4.2": {
     "description": "Fixes missing bold fonts in Chrome print view."
   },

--- a/src/components/hex-map/hex-map.js
+++ b/src/components/hex-map/hex-map.js
@@ -4,12 +4,29 @@ import classNames from 'classnames';
 
 import System from 'components/system';
 import MovementVector, { MarkerDefs } from 'components/movement-vector';
+import AbsoluteContainer from 'primitives/containers/absolute-container';
+import ContentContainer from 'primitives/containers/content-container';
+import SubContainer from 'primitives/containers/sub-container';
 
 import './style.css';
 
 export default function HexMap({ height, width, viewbox, holdKey, hexes }) {
+  let emptyMessage = null;
+  if (hexes.length === 0) {
+    emptyMessage = (
+      <AbsoluteContainer>
+        <ContentContainer direction="column" align="center" justify="center">
+          <SubContainer className="HexMap-Message">
+            Your browser window is too small to render the sector. Please try on
+            a larger screen.
+          </SubContainer>
+        </ContentContainer>
+      </AbsoluteContainer>
+    );
+  }
   return (
     <div className="HexMap-Container">
+      {emptyMessage}
       <svg
         className={classNames('HexMap-SVG', {
           'HexMap-SVG--drag': !!holdKey,

--- a/src/components/hex-map/style.scss
+++ b/src/components/hex-map/style.scss
@@ -1,4 +1,4 @@
-@import "styles/theme";
+@import 'styles/theme';
 
 .HexMap-SVG {
   display: flex;
@@ -10,6 +10,11 @@
 
 .HexMap-Container {
   background-color: $dark3;
+}
+
+.HexMap-Message {
+  color: $light3;
+  max-width: 200px;
 }
 
 @media print {


### PR DESCRIPTION
## Description

If the viewport gets really small it will hang that browser window and crash. So.... let's not do that.

If the width or height of the screen gets under 200 pixels or the number of total hexagons is greater than the maximum threshold (which is currently set at 800), then the util will short circuit and the view will render a message.

Fixes #20 