### PR TITLE
Planet Creation/Deletion

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,4 +1,12 @@
 {
+  "1.8.0": {
+    "description": "Planet creation and deletion from system edit.",
+    "changes": [
+      "In the system edit, there is a new planet multi-select.",
+      "To create a freshly generated planet, type planet name in multi-select, hit enter, and then save.",
+      "To delete planets, removing from the planet multi-select and hit save."
+    ]
+  },
   "1.7.0": {
     "description": "Planet information is now editable.",
     "changes": [

--- a/src/components/planet-info/planet-info.js
+++ b/src/components/planet-info/planet-info.js
@@ -16,7 +16,7 @@ import Label from 'primitives/form/label';
 import IconInput from 'primitives/form/icon-input';
 import Dropdown from 'primitives/form/dropdown';
 
-import { capitalizeFirstLetter, stringSortByKey } from 'utils/common';
+import { capitalizeFirstLetter } from 'utils/common';
 import { generateName } from 'utils/name-generator';
 import WorldTags from 'constants/world-tags';
 import Atmosphere from 'constants/atmosphere';
@@ -100,8 +100,6 @@ export default class PlanetInfo extends SidebarInfo {
     super(props);
 
     this.onRandomizeName = this.onRandomizeName.bind(this);
-    this.onEditName = this.onEditName.bind(this);
-    this.onEditDropdown = this.onEditDropdown.bind(this);
     this.onSavePlanet = this.onSavePlanet.bind(this);
     this.state = {
       ...props.planet,
@@ -137,7 +135,7 @@ export default class PlanetInfo extends SidebarInfo {
           temperature: this.state.temperature,
           biosphere: this.state.biosphere,
           population: this.state.population,
-          tags: this.state.tags,
+          tags: this.state.tags.map(({ value }) => value),
         },
       );
       this.onClose();
@@ -150,27 +148,6 @@ export default class PlanetInfo extends SidebarInfo {
       name: generateName(chance),
       isNotUnique: false,
     });
-  }
-
-  onEditAttribute(key, value) {
-    this.setState({
-      [key]: value,
-      isNotUnique: false,
-    });
-  }
-
-  onEditName(e) {
-    this.onEditAttribute('name', e.target.value);
-  }
-
-  onEditDropdown(key) {
-    return changed => {
-      this.onEditAttribute(
-        key,
-        changed.value ||
-          changed.sort(stringSortByKey('label')).map(({ value }) => value),
-      );
-    };
   }
 
   renderEditableDropdown(dropdownName, stateKey, constants, noPadding, dropUp) {
@@ -231,10 +208,11 @@ export default class PlanetInfo extends SidebarInfo {
             <IconInput
               id="name"
               name="name"
+              data-key="name"
               error={this.state.isNotUnique}
               icon={RefreshCw}
               value={this.state.name}
-              onChange={this.onEditName}
+              onChange={this.onEditText({ isNotUnique: false })}
               onIconClick={this.onRandomizeName}
             />
             {errorText}
@@ -281,7 +259,7 @@ export default class PlanetInfo extends SidebarInfo {
               value={this.state.tags}
               multi
               dropUp
-              onChange={this.onEditDropdown('tags')}
+              onChange={this.onEditDropdown('tags', { isNotUnique: false })}
               options={map(WorldTags, ({ name }, key) => ({
                 value: key,
                 label: name,

--- a/src/components/planet-info/planet-info.js
+++ b/src/components/planet-info/planet-info.js
@@ -182,7 +182,7 @@ export default class PlanetInfo extends SidebarInfo {
     let errorText = null;
     if (this.state.isNotUnique) {
       errorText = (
-        <div className="PlanetInfo-Error">
+        <div className="SidebarInfo-Error">
           Name must be unique in the sector.
         </div>
       );

--- a/src/components/planet-info/planet-info.js
+++ b/src/components/planet-info/planet-info.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { RefreshCw } from 'react-feather';
 import Chance from 'chance';
-import { map } from 'lodash';
+import { map, isEqual } from 'lodash';
 
 import SidebarInfo from 'components/sidebar-info';
 import SidebarNavigation, { SidebarType } from 'components/sidebar-navigation';
@@ -145,7 +145,7 @@ export default class PlanetInfo extends SidebarInfo {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.name !== nextProps.planet.name) {
+    if (!isEqual(nextProps.planet, this.props.planet)) {
       this.setState({
         ...planetStateFromProps(nextProps.planet),
       });

--- a/src/components/planet-info/planet-info.js
+++ b/src/components/planet-info/planet-info.js
@@ -108,7 +108,7 @@ export default class PlanetInfo extends SidebarInfo {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.state.name && nextProps.planet.name) {
+    if (this.state.name !== nextProps.planet.name) {
       this.setState({
         ...nextProps.planet,
       });
@@ -161,7 +161,7 @@ export default class PlanetInfo extends SidebarInfo {
           name={stateKey}
           value={this.state[stateKey]}
           clearable={false}
-          onChange={this.onEditDropdown(stateKey)}
+          onChange={this.onEditDropdown(stateKey, { isNotUnique: false })}
           dropUp={dropUp}
           options={
             Array.isArray(constants) ? (

--- a/src/components/planet-info/planet-info.js
+++ b/src/components/planet-info/planet-info.js
@@ -19,6 +19,7 @@ import Dropdown from 'primitives/form/dropdown';
 import { capitalizeFirstLetter } from 'utils/common';
 import { generateName } from 'utils/name-generator';
 import WorldTags from 'constants/world-tags';
+import TechLevel from 'constants/tech-level';
 import Atmosphere from 'constants/atmosphere';
 import Temperature from 'constants/temperature';
 import Biosphere from 'constants/biosphere';
@@ -69,6 +70,42 @@ const renderAttribute = (title, attribute, obj) => (
   </p>
 );
 
+const planetStateFromProps = ({
+  name,
+  techLevel,
+  atmosphere,
+  temperature,
+  biosphere,
+  population,
+  tags,
+}) => ({
+  name,
+  techLevel: {
+    value: techLevel,
+    label: (TechLevel[techLevel] || {}).name,
+  },
+  atmosphere: {
+    value: atmosphere,
+    label: (Atmosphere[atmosphere] || {}).name,
+  },
+  temperature: {
+    value: temperature,
+    label: (Temperature[temperature] || {}).name,
+  },
+  biosphere: {
+    value: biosphere,
+    label: (Biosphere[biosphere] || {}).name,
+  },
+  population: {
+    value: population,
+    label: (Population[population] || {}).name,
+  },
+  tags: (tags || []).map(tag => ({
+    value: tag,
+    label: (WorldTags[tag] || {}).name,
+  })),
+});
+
 export default class PlanetInfo extends SidebarInfo {
   static propTypes = {
     planet: PropTypes.shape({
@@ -102,7 +139,7 @@ export default class PlanetInfo extends SidebarInfo {
     this.onRandomizeName = this.onRandomizeName.bind(this);
     this.onSavePlanet = this.onSavePlanet.bind(this);
     this.state = {
-      ...props.planet,
+      ...planetStateFromProps(props.planet),
       isNotUnique: false,
     };
   }
@@ -110,7 +147,7 @@ export default class PlanetInfo extends SidebarInfo {
   componentWillReceiveProps(nextProps) {
     if (this.state.name !== nextProps.planet.name) {
       this.setState({
-        ...nextProps.planet,
+        ...planetStateFromProps(nextProps.planet),
       });
     }
   }
@@ -130,11 +167,11 @@ export default class PlanetInfo extends SidebarInfo {
         encodeURIComponent(this.props.routeParams.planet),
         {
           name: this.state.name,
-          techLevel: this.state.techLevel,
-          atmosphere: this.state.atmosphere,
-          temperature: this.state.temperature,
-          biosphere: this.state.biosphere,
-          population: this.state.population,
+          techLevel: this.state.techLevel.value,
+          atmosphere: this.state.atmosphere.value,
+          temperature: this.state.temperature.value,
+          biosphere: this.state.biosphere.value,
+          population: this.state.population.value,
           tags: this.state.tags.map(({ value }) => value),
         },
       );
@@ -220,15 +257,7 @@ export default class PlanetInfo extends SidebarInfo {
           {this.renderEditableDropdown(
             'Tech Level',
             'techLevel',
-            [
-              { value: 'TL0', label: 'TL0' },
-              { value: 'TL1', label: 'TL1' },
-              { value: 'TL2', label: 'TL2' },
-              { value: 'TL3', label: 'TL3' },
-              { value: 'TL4', label: 'TL4' },
-              { value: 'TL4+', label: 'TL4+' },
-              { value: 'TL5', label: 'TL5' },
-            ],
+            TechLevel,
             true,
           )}
           {this.renderEditableDropdown('Atmosphere', 'atmosphere', Atmosphere)}

--- a/src/components/planet-info/style.scss
+++ b/src/components/planet-info/style.scss
@@ -26,12 +26,6 @@
   margin: 0.2rem 1rem;
 }
 
-.PlanetInfo-Error {
-  color: red;
-  font-size: 0.9rem;
-  margin-top: 0.3rem;
-}
-
 .PlanetInfo-Editable {
   width: 48%;
 }

--- a/src/components/sector-info/sector-info.js
+++ b/src/components/sector-info/sector-info.js
@@ -81,9 +81,11 @@ export default class SectorInfo extends SidebarInfo {
           </Label>
           <IconInput
             id="name"
+            name="name"
+            data-key="name"
             icon={RefreshCw}
             value={this.state.name}
-            onChange={this.onEditName}
+            onChange={this.onEditText}
             onIconClick={this.onRandomizeName(generateSectorName)}
           />
         </Modal>

--- a/src/components/sidebar-info/sidebar-info.js
+++ b/src/components/sidebar-info/sidebar-info.js
@@ -7,8 +7,9 @@ export default class SidebarInfo extends Component {
 
     this.onEdit = this.onEdit.bind(this);
     this.onClose = this.onClose.bind(this);
-    this.onEditName = this.onEditName.bind(this);
-    this.onRandomizeName = this.onRandomizeName.bind(this);
+    this.onEditText = this.onEditText.bind(this);
+    this.onEditDropdown = this.onEditDropdown.bind(this);
+    this.updateAttribute = this.updateAttribute.bind(this);
   }
 
   state = {
@@ -24,8 +25,16 @@ export default class SidebarInfo extends Component {
     this.setState({ isOpen: false });
   }
 
-  onEditName(e) {
-    this.setState({ name: e.target.value });
+  onEditDropdown(key, extraState) {
+    return changed => {
+      this.updateAttribute(key, changed, extraState);
+    };
+  }
+
+  onEditText(extraState) {
+    return e => {
+      this.updateAttribute(e.target.dataset.key, e.target.value, extraState);
+    };
   }
 
   onRandomizeName(namingFunc) {
@@ -33,6 +42,13 @@ export default class SidebarInfo extends Component {
       const chance = new Chance();
       this.setState({ name: namingFunc(chance) });
     };
+  }
+
+  updateAttribute(key, value, extraState = {}) {
+    this.setState({
+      ...extraState,
+      [key]: value,
+    });
   }
 
   render() {

--- a/src/components/sidebar-info/sidebar-info.js
+++ b/src/components/sidebar-info/sidebar-info.js
@@ -1,6 +1,8 @@
 import { Component } from 'react';
 import Chance from 'chance';
 
+import './style.css';
+
 export default class SidebarInfo extends Component {
   constructor(props) {
     super(props);

--- a/src/components/sidebar-info/style.scss
+++ b/src/components/sidebar-info/style.scss
@@ -1,0 +1,7 @@
+@import 'styles/theme';
+
+.SidebarInfo-Error {
+  color: $error;
+  font-size: 0.9rem;
+  margin-top: 0.3rem;
+}

--- a/src/components/system-info/index.js
+++ b/src/components/system-info/index.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 
+import { getPlanetKeys } from 'store/selectors/planet.selectors';
 import { makeGetCurrentSystem } from 'store/selectors/system.selectors';
 import { editSystem } from 'store/actions/system.actions';
 import SystemInfo from './system-info';
@@ -8,6 +9,7 @@ const mapStateToProps = () => {
   const getCurrentSystem = makeGetCurrentSystem();
   return (state, props) => ({
     system: getCurrentSystem(state, props),
+    planetKeys: getPlanetKeys(state, props),
   });
 };
 

--- a/src/components/system-info/index.js
+++ b/src/components/system-info/index.js
@@ -14,8 +14,8 @@ const mapStateToProps = () => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  editSystemName: (system, value) => {
-    dispatch(editSystem(system, 'name', value));
+  editSystem: (system, changes) => {
+    dispatch(editSystem(system, changes));
   },
 });
 

--- a/src/components/system-info/system-info.js
+++ b/src/components/system-info/system-info.js
@@ -22,6 +22,11 @@ import WorldTags from 'constants/world-tags';
 
 import './style.css';
 
+const newOptionCreator = ({ label, labelKey, valueKey }) => ({
+  [labelKey]: label,
+  [valueKey]: encodeURIComponent(label.toLowerCase()),
+});
+
 export default class SectorInfo extends SidebarInfo {
   static propTypes = {
     system: PropTypes.shape({
@@ -36,7 +41,7 @@ export default class SectorInfo extends SidebarInfo {
       pathname: PropTypes.string,
       search: PropTypes.string,
     }).isRequired,
-    editSystemName: PropTypes.func.isRequired,
+    editSystem: PropTypes.func.isRequired,
     planetKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
@@ -65,7 +70,9 @@ export default class SectorInfo extends SidebarInfo {
     if (this.props.planetKeys.indexOf(nameKey) >= 0) {
       this.setState({ isNotUnique: true });
     } else {
-      this.props.editSystemName(this.props.system.key, this.state.name);
+      this.props.editSystem(this.props.system.key, {
+        name: this.state.name,
+      });
       this.onClose();
     }
   }
@@ -142,10 +149,7 @@ export default class SectorInfo extends SidebarInfo {
               onChange={this.onEditDropdown('planets')}
               options={this.getPlanetNameOptions()}
               promptTextCreator={label => `Generate new planet '${label}'`}
-              newOptionCreator={({ label, labelKey, valueKey }) => ({
-                [labelKey]: label,
-                [valueKey]: encodeURIComponent(label.toLowerCase()),
-              })}
+              newOptionCreator={newOptionCreator}
             />
           </FlexContainer>
         </Modal>

--- a/src/components/system-info/system-info.js
+++ b/src/components/system-info/system-info.js
@@ -141,6 +141,7 @@ export default class SectorInfo extends SidebarInfo {
               allowCreate
               onChange={this.onEditDropdown('planets')}
               options={this.getPlanetNameOptions()}
+              promptTextCreator={label => `Generate new planet '${label}'`}
               newOptionCreator={({ label, labelKey, valueKey }) => ({
                 [labelKey]: label,
                 [valueKey]: encodeURIComponent(label.toLowerCase()),

--- a/src/components/system-info/system-info.js
+++ b/src/components/system-info/system-info.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { map, unionBy, difference, every, zipObject } from 'lodash';
+import { map, unionBy, difference, every, zipObject, isEqual } from 'lodash';
 import { RefreshCw } from 'react-feather';
 import Chance from 'chance';
 
@@ -87,7 +87,10 @@ export default class SectorInfo extends SidebarInfo {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.name !== nextProps.system.name) {
+    if (
+      this.state.name !== nextProps.system.name ||
+      !isEqual(nextProps.system.planets, this.props.system.planets)
+    ) {
       this.setState({
         name: nextProps.system.name,
         planets: map(nextProps.system.planets, ({ name, key }) => ({
@@ -176,7 +179,7 @@ export default class SectorInfo extends SidebarInfo {
             multi
             dropUp
             allowCreate
-            onChange={this.onEditDropdown('planets')}
+            onChange={this.onEditDropdown('planets', { isNotUnique: false })}
             options={this.getPlanetNameOptions()}
             promptTextCreator={label => `Generate new planet '${label}'`}
             newOptionCreator={newOptionCreator}

--- a/src/constants/tech-level.js
+++ b/src/constants/tech-level.js
@@ -1,0 +1,9 @@
+export default {
+  TL0: { key: 'TL0', name: 'TL0' },
+  TL1: { key: 'TL1', name: 'TL1' },
+  TL2: { key: 'TL2', name: 'TL2' },
+  TL3: { key: 'TL3', name: 'TL3' },
+  TL4: { key: 'TL4', name: 'TL4' },
+  'TL4+': { key: 'TL4+', name: 'TL4+' },
+  TL5: { key: 'TL5', name: 'TL5' },
+};

--- a/src/primitives/form/dropdown/index.js
+++ b/src/primitives/form/dropdown/index.js
@@ -1,21 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Select from 'react-select';
+import Select, { Creatable } from 'react-select';
 
 import './style.css';
 
 export default function Dropdown(props) {
-  const { dropUp, ...rest } = props;
+  const { dropUp, allowCreate, ...rest } = props;
   const newProps = Object.assign(
     {
       promptTextCreator: label => label,
     },
     rest,
   );
+  const DropdownComponent = allowCreate ? Creatable : Select;
   return (
     <div className="Dropdown">
-      <Select
+      <DropdownComponent
         {...newProps}
         className={classNames('Dropdown-Select', newProps.className, {
           'Dropdoown-Up': dropUp,
@@ -29,9 +30,11 @@ export default function Dropdown(props) {
 Dropdown.propTypes = {
   ...Select.propTypes,
   dropUp: PropTypes.bool,
+  allowCreate: PropTypes.bool,
 };
 
 Dropdown.defaultProps = {
   options: [],
   dropUp: false,
+  allowCreate: false,
 };

--- a/src/store/actions/system.actions.js
+++ b/src/store/actions/system.actions.js
@@ -12,22 +12,22 @@ export const SYSTEM_HOVER_START = 'SYSTEM_HOVER_START';
 export const SYSTEM_HOVER_END = 'SYSTEM_HOVER_END';
 export const EDIT_SYSTEM = 'EDIT_SYSTEM';
 
-export function editSystem(system, key, value) {
+export function editSystem(system, changes) {
   return (dispatch, getState) => {
     const state = getState();
     const sector = { ...getCurrentSector(state), updated: Date.now() };
     sector.created = sector.created || Date.now();
-    const updateSystem = { ...sector.systems[system], [key]: value };
+    const update = { ...sector.systems[system], ...changes };
     return localForage
       .setItem(sector.seed, {
         ...sector,
         systems: {
           ...sector.systems,
-          [system]: updateSystem,
+          [system]: update,
         },
       })
       .then(() => {
-        dispatch({ type: EDIT_SYSTEM, system, update: updateSystem });
+        dispatch({ type: EDIT_SYSTEM, system, update });
         dispatch(
           ReduxToastrActions.add({
             options: {

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -7,3 +7,5 @@ $light1: #8f8f8f;
 $light2: #b2b2b2;
 $light3: #dbdbdb;
 $light4: #e3e3e3;
+
+$error: #fa755a;

--- a/src/utils/sector-generator.js
+++ b/src/utils/sector-generator.js
@@ -9,8 +9,8 @@ import Temperature from 'constants/temperature';
 import Biosphere from 'constants/biosphere';
 import Population from 'constants/population';
 
-const generatePlanet = seededChance => () => {
-  const name = generateName(seededChance);
+export const generatePlanet = (seededChance, existingName) => () => {
+  const name = existingName || generateName(seededChance);
   return {
     name,
     key: encodeURIComponent(name.toLowerCase()),


### PR DESCRIPTION
## Description

In the edit system modal, a new planets multi-select dropdown is available. You can easily delete existing planets from the sector or add newly generated planets. To edit the planet information you drill into the planet like normal.

As in the planet edit modal, unique planet names are enforced across the sector as the encoded string name is the key saved on the model.

![](http://g.recordit.co/erKByLhoEB.gif)