### PR TITLE
Fix issue when editing planet with space in name

### DIFF
--- a/src/components/planet-edit-modal/index.js
+++ b/src/components/planet-edit-modal/index.js
@@ -8,7 +8,7 @@ import PlanetEditModal from './planet-edit-modal';
 const mapStateToProps = (state, props) => ({
   planetKeys: getPlanetKeys(state),
   planet: getCurrentSector(state).systems[props.systemKey].planets[
-    props.planetKey
+    encodeURIComponent(props.planetKey)
   ],
 });
 


### PR DESCRIPTION
The edit modal thinks you are trying to create a new planet.