### PR TITLE
Hide Entities from Players

### DIFF
--- a/src/components/hex-map/style.scss
+++ b/src/components/hex-map/style.scss
@@ -10,6 +10,7 @@
 
 .HexMap-Container {
   background-color: $dark3;
+  overflow: hidden;
   position: relative;
 }
 

--- a/src/components/sidebar-entity/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entity/entity-attributes/entity-attributes.js
@@ -6,6 +6,7 @@ import { RefreshCw } from 'react-feather';
 import SectionHeader from 'primitives/text/section-header';
 import Dropdown from 'primitives/form/dropdown';
 import IconInput from 'primitives/form/icon-input';
+import Input from 'primitives/form/input';
 
 import Entities from 'constants/entities';
 
@@ -37,6 +38,7 @@ export default function EntityAttributes({
   isTagsOpen,
   toggleAttributesOpen,
   toggleTagsOpen,
+  isAncestorHidden,
 }) {
   const noAttributes =
     !entity.attributes || !Object.keys(entity.attributes).length;
@@ -51,6 +53,7 @@ export default function EntityAttributes({
 
   if (isSidebarEditActive || hasNonTagAttributes) {
     let nameAttribute = null;
+    let hiddenAttribute = null;
     if (isSidebarEditActive) {
       nameAttribute = (
         <div className="EntityAttributes-Attribute">
@@ -68,6 +71,22 @@ export default function EntityAttributes({
           />
         </div>
       );
+      if (entityType !== Entities.sector.key) {
+        hiddenAttribute = (
+          <div className="EntityAttributes-Attribute">
+            <b className="EntityAttributes-Header">Is Hidden:</b>
+            <Input
+              className="EntityAttributes-Item"
+              type="checkbox"
+              checked={!!entity.isHidden || isAncestorHidden}
+              disabled={isAncestorHidden}
+              onChange={({ target }) =>
+                updateEntityInEdit({ name: target.checked })
+              }
+            />
+          </div>
+        );
+      }
     }
 
     // eslint-disable-next-line react/prop-types
@@ -99,6 +118,7 @@ export default function EntityAttributes({
               (entity.attributes || {})[attribute.key],
             ),
           )}
+          {hiddenAttribute}
         </div>
       );
     }
@@ -138,6 +158,7 @@ EntityAttributes.propTypes = {
   isTagsOpen: PropTypes.bool.isRequired,
   toggleAttributesOpen: PropTypes.func.isRequired,
   toggleTagsOpen: PropTypes.func.isRequired,
+  isAncestorHidden: PropTypes.bool.isRequired,
 };
 
 EntityAttributes.defaultProps = {

--- a/src/components/sidebar-entity/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entity/entity-attributes/entity-attributes.js
@@ -81,7 +81,7 @@ export default function EntityAttributes({
               checked={!!entity.isHidden || isAncestorHidden}
               disabled={isAncestorHidden}
               onChange={({ target }) =>
-                updateEntityInEdit({ name: target.checked })
+                updateEntityInEdit({ isHidden: target.checked })
               }
             />
           </div>

--- a/src/components/sidebar-entity/entity-attributes/index.js
+++ b/src/components/sidebar-entity/entity-attributes/index.js
@@ -4,6 +4,7 @@ import {
   getCurrentEntity,
   getCurrentEntityId,
   getCurrentEntityType,
+  isAncestorHidden,
 } from 'store/selectors/entity.selectors';
 import { isSidebarEditActiveSelector } from 'store/selectors/base.selectors';
 import { updateEntityInEdit } from 'store/actions/sidebar-edit.actions';
@@ -15,6 +16,7 @@ const mapStateToProps = state => ({
   entityId: getCurrentEntityId(state),
   entityType: getCurrentEntityType(state),
   isSidebarEditActive: isSidebarEditActiveSelector(state),
+  isAncestorHidden: isAncestorHidden(state),
 });
 
 export default connect(mapStateToProps, { updateEntityInEdit })(

--- a/src/components/sidebar-entity/entity-attributes/style.scss
+++ b/src/components/sidebar-entity/entity-attributes/style.scss
@@ -36,6 +36,7 @@
 .EntityAttributes-Header {
   display: table-cell;
   padding-right: 0.5rem;
+  vertical-align: middle;
 }
 
 .EntityAttributes-Item {

--- a/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
+++ b/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
@@ -80,13 +80,20 @@ export default function EntityEditRow({
       {dropdown}
       {input}
       <Input
-        className="EntityEditRow-Generate"
+        className="EntityEditRow-Checkbox"
         disabled={!entity.isCreated}
         checked={!entity.isCreated || entity.generate}
         onChange={({ target }) =>
           updateChildInEdit({ generate: target.checked })
         }
-        name="checkbox"
+        type="checkbox"
+      />
+      <Input
+        className="EntityEditRow-Checkbox"
+        checked={entity.isHidden || false}
+        onChange={({ target }) =>
+          updateChildInEdit({ isHidden: target.checked })
+        }
         type="checkbox"
       />
     </FlexContainer>

--- a/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
+++ b/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { X, RefreshCw, RotateCcw } from 'react-feather';
+import ReactHintFactory from 'react-hint';
 
 import FlexContainer from 'primitives/container/flex-container';
 import Input from 'primitives/form/input';
@@ -12,6 +13,8 @@ import { coordinateKey, coordinatesFromKey } from 'utils/common';
 
 import './style.css';
 
+const ReactHint = ReactHintFactory(React);
+
 export default function EntityEditRow({
   entity,
   entityType,
@@ -19,6 +22,7 @@ export default function EntityEditRow({
   deleteChildInEdit,
   undoDeleteChildInEdit,
   updateChildInEdit,
+  isCurrentOrAncestorHidden,
 }) {
   const entityConfig = Entities[entityType];
 
@@ -88,14 +92,24 @@ export default function EntityEditRow({
         }
         type="checkbox"
       />
-      <Input
-        className="EntityEditRow-Checkbox"
-        checked={entity.isHidden || false}
-        onChange={({ target }) =>
-          updateChildInEdit({ isHidden: target.checked })
+      <span
+        data-rh={
+          isCurrentOrAncestorHidden
+            ? `A parent entity is hiding this ${entityConfig.shortName.toLowerCase()}.`
+            : null
         }
-        type="checkbox"
-      />
+      >
+        <Input
+          className="EntityEditRow-Checkbox"
+          disabled={isCurrentOrAncestorHidden}
+          checked={entity.isHidden || isCurrentOrAncestorHidden || false}
+          onChange={({ target }) =>
+            updateChildInEdit({ isHidden: target.checked })
+          }
+          type="checkbox"
+        />
+      </span>
+      <ReactHint events position="left" />
     </FlexContainer>
   );
 }
@@ -116,6 +130,7 @@ EntityEditRow.propTypes = {
   deleteChildInEdit: PropTypes.func.isRequired,
   undoDeleteChildInEdit: PropTypes.func.isRequired,
   updateChildInEdit: PropTypes.func.isRequired,
+  isCurrentOrAncestorHidden: PropTypes.bool.isRequired,
 };
 
 EntityEditRow.defaultProps = {

--- a/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
+++ b/src/components/sidebar-entity/entity-edit-row/entity-edit-row.js
@@ -110,6 +110,7 @@ EntityEditRow.propTypes = {
     isDeleted: PropTypes.bool,
     isCreated: PropTypes.bool,
     generate: PropTypes.bool,
+    isHidden: PropTypes.bool,
   }).isRequired,
   emptyHexKeys: PropTypes.arrayOf(PropTypes.string),
   deleteChildInEdit: PropTypes.func.isRequired,

--- a/src/components/sidebar-entity/entity-edit-row/index.js
+++ b/src/components/sidebar-entity/entity-edit-row/index.js
@@ -5,8 +5,10 @@ import {
   undoDeleteChildInEdit,
   updateChildInEdit,
 } from 'store/actions/sidebar-edit.actions';
-import { isCurrentOrAncestorHidden } from 'store/selectors/entity.selectors';
-import { getEmptyHexKeys } from 'store/selectors/sector.selectors';
+import {
+  isCurrentOrAncestorHidden,
+  getEmptyHexKeys,
+} from 'store/selectors/entity.selectors';
 import EntityEditRow from './entity-edit-row';
 
 const mapStateToProps = state => ({

--- a/src/components/sidebar-entity/entity-edit-row/index.js
+++ b/src/components/sidebar-entity/entity-edit-row/index.js
@@ -5,11 +5,13 @@ import {
   undoDeleteChildInEdit,
   updateChildInEdit,
 } from 'store/actions/sidebar-edit.actions';
+import { isCurrentOrAncestorHidden } from 'store/selectors/entity.selectors';
 import { getEmptyHexKeys } from 'store/selectors/sector.selectors';
 import EntityEditRow from './entity-edit-row';
 
 const mapStateToProps = state => ({
   emptyHexKeys: getEmptyHexKeys(state),
+  isCurrentOrAncestorHidden: isCurrentOrAncestorHidden(state),
 });
 
 const mapDispatchToProps = (dispatch, props) => ({

--- a/src/components/sidebar-entity/entity-edit-row/style.scss
+++ b/src/components/sidebar-entity/entity-edit-row/style.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.EntityEditRow-Generate {
+.EntityEditRow-Checkbox {
   margin-left: 0.5rem;
   margin-right: 0;
 }

--- a/src/components/sidebar-entity/entity-link-row/entity-link-row.js
+++ b/src/components/sidebar-entity/entity-link-row/entity-link-row.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { EyeOff } from 'react-feather';
 
 import LinkRow from 'primitives/other/link-row';
 
@@ -9,6 +10,7 @@ export default function EntityLinkRow({ entity, entityType, currentSector }) {
       to={`/sector/${currentSector}/${entityType}/${entity.entityId}`}
       title={entity.name}
       additional={entity.additional}
+      additionalIcon={entity.isHidden ? EyeOff : null}
     />
   );
 }
@@ -18,6 +20,7 @@ EntityLinkRow.propTypes = {
     entityId: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     additional: PropTypes.string,
+    isHidden: PropTypes.bool,
   }).isRequired,
   entityType: PropTypes.string.isRequired,
   currentSector: PropTypes.string.isRequired,

--- a/src/components/sidebar-entity/entity-link-row/entity-link-row.js
+++ b/src/components/sidebar-entity/entity-link-row/entity-link-row.js
@@ -4,13 +4,20 @@ import { EyeOff } from 'react-feather';
 
 import LinkRow from 'primitives/other/link-row';
 
-export default function EntityLinkRow({ entity, entityType, currentSector }) {
+export default function EntityLinkRow({
+  entity,
+  entityType,
+  currentSector,
+  isCurrentOrAncestorHidden,
+}) {
   return (
     <LinkRow
       to={`/sector/${currentSector}/${entityType}/${entity.entityId}`}
       title={entity.name}
       additional={entity.additional}
-      additionalIcon={entity.isHidden ? EyeOff : null}
+      additionalIcon={
+        entity.isHidden || isCurrentOrAncestorHidden ? EyeOff : null
+      }
     />
   );
 }
@@ -24,4 +31,5 @@ EntityLinkRow.propTypes = {
   }).isRequired,
   entityType: PropTypes.string.isRequired,
   currentSector: PropTypes.string.isRequired,
+  isCurrentOrAncestorHidden: PropTypes.bool.isRequired,
 };

--- a/src/components/sidebar-entity/entity-link-row/index.js
+++ b/src/components/sidebar-entity/entity-link-row/index.js
@@ -1,11 +1,13 @@
 import { connect } from 'react-redux';
 
 import { currentSectorSelector } from 'store/selectors/base.selectors';
+import { isCurrentOrAncestorHidden } from 'store/selectors/entity.selectors';
 
 import EntityLinkRow from './entity-link-row';
 
 const mapStateToProps = state => ({
   currentSector: currentSectorSelector(state),
+  isCurrentOrAncestorHidden: isCurrentOrAncestorHidden(state),
 });
 
 export default connect(mapStateToProps)(EntityLinkRow);

--- a/src/components/sidebar-entity/entity-list/entity-list.js
+++ b/src/components/sidebar-entity/entity-list/entity-list.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Pluralize from 'pluralize';
 import { map, size, isNumber } from 'lodash';
-import { Plus } from 'react-feather';
+import { Plus, EyeOff } from 'react-feather';
 import ReactHintFactory from 'react-hint';
 
 import FlexContainer from 'primitives/container/flex-container';
@@ -82,12 +82,18 @@ const EntityList = ({
     return (
       <FlexContainer
         justify="flexEnd"
-        align="flexEnd"
+        align="center"
         className="EntityList-SubHeader"
       >
         <Dice
           data-rh={`Select to generate ${Entities[entityType].name} data.`}
           size={22}
+        />
+        <LinkIcon
+          data-rh="Select to keep hidden from your players."
+          className="EntityList-SubHeaderHidden"
+          icon={EyeOff}
+          size={18}
         />
       </FlexContainer>
     );

--- a/src/components/sidebar-entity/entity-list/entity-list.js
+++ b/src/components/sidebar-entity/entity-list/entity-list.js
@@ -76,7 +76,7 @@ const EntityList = ({
   };
 
   const renderEntitySubHeader = () => {
-    if (!isSidebarEditActive || !size(entities)) {
+    if (!isSidebarEditActive || !size(entities) || !isOpen) {
       return null;
     }
     return (

--- a/src/components/sidebar-entity/entity-list/entity-list.js
+++ b/src/components/sidebar-entity/entity-list/entity-list.js
@@ -86,7 +86,9 @@ const EntityList = ({
         className="EntityList-SubHeader"
       >
         <Dice
-          data-rh={`Select to generate ${Entities[entityType].name} data.`}
+          data-rh={`Select to generate ${(
+            Entities[entityType].shortName || ''
+          ).toLowerCase()} data.`}
           size={22}
         />
         <LinkIcon

--- a/src/components/sidebar-entity/entity-list/style.scss
+++ b/src/components/sidebar-entity/entity-list/style.scss
@@ -5,6 +5,7 @@
 }
 
 .EntityList-SubHeader {
+  color: $light2;
   margin: 0 1rem;
 }
 
@@ -15,4 +16,8 @@
 
 .EntityList-Name {
   cursor: pointer;
+}
+
+.EntityList-SubHeaderHidden {
+  margin: 0rem 0.1rem 0 0.5rem;
 }

--- a/src/primitives/container/content-container/style.scss
+++ b/src/primitives/container/content-container/style.scss
@@ -1,4 +1,4 @@
 .ContentContainer {
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }

--- a/src/primitives/container/flex-container/style.scss
+++ b/src/primitives/container/flex-container/style.scss
@@ -85,5 +85,5 @@
 }
 
 .FlexContainer-Scroll {
-  overflow: scroll;
+  overflow-y: auto;
 }

--- a/src/primitives/other/link-row/index.js
+++ b/src/primitives/other/link-row/index.js
@@ -1,37 +1,62 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { ChevronRight } from 'react-feather';
+import classNames from 'classnames';
 
 import FlexContainer from 'primitives/container/flex-container';
 import Header, { HeaderType } from 'primitives/text/header';
 
 import './style.css';
 
-export default function LinkRow({ to, title, additional }) {
-  return (
-    <Link className="LinkRow" to={to}>
-      <FlexContainer justify="spaceBetween" flex="1">
-        <FlexContainer flex="1" align="baseline">
-          <Header type={HeaderType.header4} className="LinkRow-Name">
-            {title}
-          </Header>
-          {additional && (
-            <div className="LinkRow-Additional">({additional})</div>
-          )}
+export default class LinkRow extends Component {
+  state = {
+    hovered: false,
+  };
+
+  render() {
+    const { to, title, additional, additionalIcon } = this.props;
+    const Icon = this.state.hovered
+      ? ChevronRight
+      : additionalIcon || ChevronRight;
+    return (
+      <Link
+        className="LinkRow"
+        to={to}
+        onMouseOver={() => this.setState({ hovered: true })}
+        onFocus={() => this.setState({ hovered: true })}
+        onMouseOut={() => this.setState({ hovered: false })}
+        onBlur={() => this.setState({ hovered: false })}
+      >
+        <FlexContainer justify="spaceBetween" flex="1">
+          <FlexContainer flex="1" align="baseline">
+            <Header type={HeaderType.header4} className="LinkRow-Name">
+              {title}
+            </Header>
+            {additional && (
+              <div className="LinkRow-Additional">({additional})</div>
+            )}
+          </FlexContainer>
+          <Icon
+            size={additionalIcon && !this.state.hovered ? 16 : 20}
+            className={classNames('LinkRow-RightArrow', {
+              'LinkRow-AdditionalIcon': additionalIcon,
+            })}
+          />
         </FlexContainer>
-        <ChevronRight className="LinkRow-RightArrow" />
-      </FlexContainer>
-    </Link>
-  );
+      </Link>
+    );
+  }
 }
 
 LinkRow.propTypes = {
   to: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   additional: PropTypes.string,
+  additionalIcon: PropTypes.node,
 };
 
 LinkRow.defaultProps = {
   additional: null,
+  additionalIcon: null,
 };

--- a/src/primitives/other/link-row/index.js
+++ b/src/primitives/other/link-row/index.js
@@ -53,7 +53,7 @@ LinkRow.propTypes = {
   to: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   additional: PropTypes.string,
-  additionalIcon: PropTypes.node,
+  additionalIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 LinkRow.defaultProps = {

--- a/src/primitives/other/link-row/style.scss
+++ b/src/primitives/other/link-row/style.scss
@@ -22,6 +22,7 @@
 
 .LinkRow-RightArrow {
   color: $dark3;
+  pointer-events: none;
   transition: color 0.5s;
 }
 
@@ -29,4 +30,8 @@
   color: $light1;
   font-size: 0.8rem;
   margin-left: 0.5rem;
+}
+
+.LinkRow-AdditionalIcon {
+  color: $light2;
 }

--- a/src/store/actions/entity.actions.js
+++ b/src/store/actions/entity.actions.js
@@ -36,6 +36,7 @@ import { isCurrentSectorSaved } from 'store/selectors/sector.selectors';
 import {
   generateEntity as generateEntityUtil,
   deleteEntity as deleteEntityUtil,
+  blacklistedAttributes,
   getTopLevelEntity,
 } from 'utils/entity';
 import { coordinatesFromKey } from 'utils/common';
@@ -238,6 +239,7 @@ export const saveEntityEdit = () => (dispatch, getState) => {
       mapValues(
         entities,
         ({ isCreated, isDeleted, isUpdated, ...thisEntity }, thisEntityId) => {
+          const filteredEntity = omit(thisEntity, blacklistedAttributes);
           if (isCreated) {
             createdEntities = merge(
               createdEntities,
@@ -246,7 +248,7 @@ export const saveEntityEdit = () => (dispatch, getState) => {
                 currentSector: currentSectorSelector(state),
                 configuration: configurationSelector(state),
                 parameters: {
-                  ...thisEntity,
+                  ...filteredEntity,
                   parentEntity: currentEntityType,
                   parent: currentEntityId,
                 },
@@ -267,7 +269,9 @@ export const saveEntityEdit = () => (dispatch, getState) => {
               },
             );
           }
-          return isDeleted || isCreated || !isUpdated ? undefined : thisEntity;
+          return isDeleted || isCreated || !isUpdated
+            ? undefined
+            : filteredEntity;
         },
       ),
       isNil,

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -47,11 +47,12 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
     children: pickBy(
       mapValues(childrenByType, childType => {
         const sortedChildren = sortBy(
-          mapValues(childType, (child, key) => ({
+          mapValues(childType, ({ name, x, y, isHidden }, key) => ({
             key,
-            name: child.name,
-            x: child.x,
-            y: child.y,
+            name,
+            x,
+            y,
+            isHidden,
           })),
           ({ x, y, name }) =>
             isNumber(x) && isNumber(y) ? coordinateKey(x, y) : name,
@@ -59,12 +60,10 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
 
         return zipObject(
           sortedChildren.map(({ key }) => key),
-          sortedChildren.map(({ x, y, name }, index) =>
+          sortedChildren.map((child, index) =>
             omitBy(
               {
-                x,
-                y,
-                name,
+                ...child,
                 sort: sortedChildren.length - index - 1,
               },
               isNil,

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -43,7 +43,14 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
   const childrenByType = getCurrentEntityChildren(state);
   return dispatch({
     type: ACTIVATE_SIDEBAR_EDIT,
-    entity: omitBy({ name: entity.name, attributes: entity.attributes }, isNil),
+    entity: omitBy(
+      {
+        name: entity.name,
+        attributes: entity.attributes,
+        isHidden: entity.isHidden,
+      },
+      isNil,
+    ),
     children: pickBy(
       mapValues(childrenByType, childType => {
         const sortedChildren = sortBy(

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -10,6 +10,7 @@ import {
 } from 'lodash';
 
 import {
+  getEmptyHexKeys,
   getCurrentEntity,
   getCurrentEntityId,
   getCurrentEntityType,
@@ -19,7 +20,6 @@ import {
   sidebarEditChildrenSelector,
   syncLockSelector,
 } from 'store/selectors/base.selectors';
-import { getEmptyHexKeys } from 'store/selectors/sector.selectors';
 import Entities from 'constants/entities';
 import { createId, coordinatesFromKey, coordinateKey } from 'utils/common';
 import { syncLock } from 'store/utils';

--- a/src/store/reducers/sector.reducers.js
+++ b/src/store/reducers/sector.reducers.js
@@ -99,6 +99,7 @@ export default function sector(state = initialState, action) {
       return {
         ...state,
         saved: keys(action.entities[Entities.sector.key] || {}),
+        shared: [],
       };
     case LOGGED_OUT:
       return {

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -22,12 +22,16 @@ import Entities from 'constants/entities';
 import { allSectorKeys, coordinateKey } from 'utils/common';
 
 export const getCurrentTopLevelEntities = createSelector(
-  [currentSectorSelector, entitySelector],
-  (currentSector, entities) =>
+  [currentSectorSelector, entitySelector, isViewingSharedSector],
+  (currentSector, entities, isShared) =>
     Object.assign(
       ...filter(Entities, ({ topLevel }) => topLevel).map(({ key }) =>
         mapValues(
-          pickBy(entities[key], ({ sector }) => sector === currentSector),
+          pickBy(
+            entities[key],
+            ({ sector, isHidden }) =>
+              sector === currentSector && (!isShared || !isHidden),
+          ),
           (entity, entityId) => ({
             ...entity,
             type: key,

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -38,8 +38,11 @@ export const getCurrentTopLevelEntities = createSelector(
             numChildren: Entities[key].children.reduce(
               (total, childKey) =>
                 total +
-                filter(entities[childKey], ({ parent }) => parent === entityId)
-                  .length,
+                filter(
+                  entities[childKey],
+                  ({ parent, isHidden }) =>
+                    parent === entityId && (!isShared || !isHidden),
+                ).length,
               0,
             ),
           }),

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -49,13 +49,14 @@ export const getCurrentTopLevelEntities = createSelector(
 );
 
 export const getCurrentEntities = createSelector(
-  [currentSectorSelector, entitySelector],
-  (currentSector, entities) =>
+  [currentSectorSelector, entitySelector, isViewingSharedSector],
+  (currentSector, entities, isShared) =>
     mapValues(entities, entityList =>
       pickBy(
         entityList,
-        (entity, entityId) =>
-          entity.sector === currentSector || entityId === currentSector,
+        ({ sector, isHidden }, entityId) =>
+          (sector === currentSector || entityId === currentSector) &&
+          (!isShared || !isHidden),
       ),
     ),
 );

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -1,5 +1,12 @@
 import { createSelector } from 'reselect';
-import { filter, pickBy, mapValues, zipObject } from 'lodash';
+import {
+  filter,
+  pickBy,
+  mapValues,
+  zipObject,
+  difference,
+  values,
+} from 'lodash';
 
 import {
   currentSectorSelector,
@@ -8,8 +15,11 @@ import {
   entitySelector,
   isSidebarEditActiveSelector,
   sidebarEditEntitySelector,
+  sidebarEditChildrenSelector,
 } from 'store/selectors/base.selectors';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import Entities from 'constants/entities';
+import { allSectorKeys, coordinateKey } from 'utils/common';
 
 export const getCurrentTopLevelEntities = createSelector(
   [currentSectorSelector, entitySelector],
@@ -88,16 +98,36 @@ export const getCurrentEntityId = createSelector(
 );
 
 export const getCurrentEntityChildren = createSelector(
-  [getCurrentEntityId, getCurrentEntityType, entitySelector],
-  (entityId, currentEntityType, entities) => {
+  [
+    getCurrentEntityId,
+    getCurrentEntityType,
+    entitySelector,
+    isViewingSharedSector,
+  ],
+  (entityId, currentEntityType, entities, isShared) => {
     const entityChildren = Entities[currentEntityType].children;
     return zipObject(
       entityChildren,
       entityChildren.map(entityType =>
-        pickBy(entities[entityType], ({ parent }) => parent === entityId),
+        pickBy(
+          entities[entityType],
+          ({ parent, isHidden }) =>
+            parent === entityId && (!isShared || !isHidden),
+        ),
       ),
     );
   },
+);
+
+export const getEmptyHexKeys = createSelector(
+  [getCurrentSector, sidebarEditChildrenSelector],
+  ({ rows, columns }, children = {}) =>
+    difference(
+      allSectorKeys(columns, rows),
+      values(Object.assign({}, ...values(children))).map(({ x, y }) =>
+        coordinateKey(x, y),
+      ),
+    ),
 );
 
 export const isCurrentOrAncestorHidden = createSelector(

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -130,16 +130,17 @@ export const getEmptyHexKeys = createSelector(
     ),
 );
 
-export const isCurrentOrAncestorHidden = createSelector(
+export const isAncestorHidden = createSelector(
   [getCurrentEntityId, getCurrentEntityType, entitySelector],
   (currentEntityId, currentEntityType, entities) => {
     if (currentEntityType === Entities.sector.key) {
       return false;
     }
+    const currentEntity = entities[currentEntityType][currentEntityId];
     let thisEntity = {
-      ...entities[currentEntityType][currentEntityId],
+      ...entities[currentEntity.parentEntity][currentEntity.parent],
     };
-    let thisEntityType = currentEntityType;
+    let thisEntityType = currentEntity.parentEntity;
     let isHidden = !!thisEntity.isHidden;
     while (thisEntityType !== Entities.sector.key && !isHidden) {
       isHidden = !!thisEntity.isHidden;
@@ -150,4 +151,11 @@ export const isCurrentOrAncestorHidden = createSelector(
     }
     return isHidden;
   },
+);
+
+export const isCurrentOrAncestorHidden = createSelector(
+  [isAncestorHidden, getCurrentEntityId, getCurrentEntityType, entitySelector],
+  (ancestorHidden, currentEntityId, currentEntityType, entities) =>
+    currentEntityType !== Entities.sector.key &&
+    (ancestorHidden || !!entities[currentEntityType][currentEntityId].isHidden),
 );

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -99,3 +99,25 @@ export const getCurrentEntityChildren = createSelector(
     );
   },
 );
+
+export const isCurrentOrAncestorHidden = createSelector(
+  [getCurrentEntityId, getCurrentEntityType, entitySelector],
+  (currentEntityId, currentEntityType, entities) => {
+    if (currentEntityType === Entities.sector.key) {
+      return false;
+    }
+    let thisEntity = {
+      ...entities[currentEntityType][currentEntityId],
+    };
+    let thisEntityType = currentEntityType;
+    let isHidden = !!thisEntity.isHidden;
+    while (thisEntityType !== Entities.sector.key && !isHidden) {
+      isHidden = !!thisEntity.isHidden;
+      thisEntityType = thisEntity.parentEntity;
+      thisEntity = {
+        ...entities[thisEntityType][thisEntity.parent],
+      };
+    }
+    return isHidden;
+  },
+);

--- a/src/store/selectors/sector.selectors.js
+++ b/src/store/selectors/sector.selectors.js
@@ -1,15 +1,12 @@
-import { omitBy, difference, values, includes } from 'lodash';
+import { omitBy, includes } from 'lodash';
 import { createSelector } from 'reselect';
 
-import { allSectorKeys, coordinateKey } from 'utils/common';
 import {
   currentSectorSelector,
   sectorSelector,
-  sidebarEditChildrenSelector,
   savedSectorSelector,
   sharedSectorSelector,
 } from 'store/selectors/base.selectors';
-import { getCurrentSector } from 'store/selectors/entity.selectors';
 
 export const getUserSectors = createSelector(
   [sectorSelector, savedSectorSelector],
@@ -28,15 +25,4 @@ export const isCurrentSectorSaved = createSelector(
 export const isViewingSharedSector = createSelector(
   [currentSectorSelector, sharedSectorSelector],
   (currentSector, shared) => includes(shared, currentSector),
-);
-
-export const getEmptyHexKeys = createSelector(
-  [getCurrentSector, sidebarEditChildrenSelector],
-  ({ rows, columns }, children = {}) =>
-    difference(
-      allSectorKeys(columns, rows),
-      values(Object.assign({}, ...values(children))).map(({ x, y }) =>
-        coordinateKey(x, y),
-      ),
-    ),
 );


### PR DESCRIPTION
## Description

Only entities are being filtered from players. Attributes and world tags are always shown on available entities. The ability to turn those on/off is a separate ticket (#85).

Resolves #35

<img width="958" alt="screen shot 2018-02-04 at 11 48 03 am" src="https://user-images.githubusercontent.com/3017491/35780457-49b62f96-09a1-11e8-905a-571c73189b4b.png">
