### PR TITLE
Fix System Num Offset in Print Dialog

### DIFF
--- a/src/components/hex/style.scss
+++ b/src/components/hex/style.scss
@@ -74,19 +74,26 @@
 }
 
 @media print {
-  .Hex-System,
+  .Hex-BlackHole,
   .Hex-Text {
     fill: $dark4;
     stroke: $dark4;
     font-size: 25px;
   }
 
+  .Hex-System {
+    stroke: $dark4;
+    fill: white;
+    font-size: 25px;
+    stroke-width: 6px;
+  }
+
   .Hex-Name {
     display: block;
   }
 
-  .Hex-Childrens {
-    transform: translateY(21px);
+  .Hex-Children {
+    transform: translateY(25px);
   }
 
   .Hex-Key {


### PR DESCRIPTION
Also prints the systems without a fill to differentiate them from black holes.

Fixes #92 

<img width="499" alt="screen shot 2018-02-12 at 7 57 25 am" src="https://user-images.githubusercontent.com/3017491/36100124-cc3e6012-0fca-11e8-9bd2-ef86a3ebc8b5.png">
