### PR TITLE
Fix Tooltip Positioning

### DIFF
--- a/src/components/entity-tooltips/entity-tooltips.js
+++ b/src/components/entity-tooltips/entity-tooltips.js
@@ -4,7 +4,12 @@ import classNames from 'classnames';
 
 import './style.css';
 
-export default function EntityTooltips({ hoverKey, holdKey, hexes }) {
+export default function EntityTooltips({
+  hoverKey,
+  holdKey,
+  hexes,
+  leftOffset,
+}) {
   const renderTooltip = system => (
     <div
       className={classNames('EntityTooltips-Tooltip', {
@@ -14,7 +19,7 @@ export default function EntityTooltips({ hoverKey, holdKey, hexes }) {
       key={system.hexKey}
       style={{
         top: system.yOffset - system.height / 2 - 10,
-        left: system.xOffset,
+        left: system.xOffset + leftOffset,
       }}
     >
       <div className="EntityTooltips-Text">
@@ -30,6 +35,7 @@ export default function EntityTooltips({ hoverKey, holdKey, hexes }) {
 EntityTooltips.propTypes = {
   hoverKey: PropTypes.string,
   holdKey: PropTypes.string,
+  leftOffset: PropTypes.number,
   hexes: PropTypes.arrayOf(
     PropTypes.shape({
       hexKey: PropTypes.string.isRequired,
@@ -44,4 +50,5 @@ EntityTooltips.propTypes = {
 EntityTooltips.defaultProps = {
   hoverKey: null,
   holdKey: null,
+  leftOffset: 0,
 };

--- a/src/components/sector-map/sector-map.js
+++ b/src/components/sector-map/sector-map.js
@@ -19,6 +19,7 @@ import Error from './error';
 
 import './style.css';
 
+const calcNavWidth = () => (window.innerWidth > 1500 ? 188 : 75);
 const calcWidth = () => {
   let width = window.innerWidth - 75;
   if (window.innerWidth > 1200) {
@@ -85,6 +86,7 @@ export default class SectorMap extends Component {
     }
     return (
       <EntityTooltips
+        leftOffset={calcNavWidth()}
         hexes={map(this.props.topLevelEntities, entity => ({
           ...entity,
           ...hexData.find(


### PR DESCRIPTION
## Description

After the sector summary went out and the left navigation was introduced the tooltips were misaligned to the left the size of the navigation bar.

Fixes #101 