### PR TITLE
Export CSV Files from Overview Table Header

### DIFF
--- a/src/components/overview-table/index.js
+++ b/src/components/overview-table/index.js
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux';
 
-import { getPrintableEntities } from 'store/selectors/entity.selectors';
+import {
+  getPrintableEntities,
+  getCurrentSector,
+} from 'store/selectors/entity.selectors';
 import OverviewTable from './overview-table';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
+  currentSector: getCurrentSector(state),
 });
 
 export default connect(mapStateToProps)(OverviewTable);

--- a/src/components/overview-table/style.scss
+++ b/src/components/overview-table/style.scss
@@ -19,3 +19,7 @@
 .OverviewTable-Table {
   font-size: 0.75rem;
 }
+
+.OverviewTable-FlexWrap {
+  width: 100%;
+}

--- a/src/utils/__tests__/export.spec.js
+++ b/src/utils/__tests__/export.spec.js
@@ -1,0 +1,42 @@
+import { generateCSV } from '../export';
+
+describe('Export Util', () => {
+  describe('generateCSV', () => {
+    it('should return a string given an array', () => {
+      const csv = generateCSV([[]]);
+      expect(typeof csv).toEqual('string');
+    });
+
+    it('should return a string that starts with CSV front-matter', () => {
+      const csv = generateCSV([[]]);
+      expect(csv.indexOf('data:text/csv;charset=utf-8,')).toEqual(0);
+    });
+
+    it("shouldn't error if the table is an empty array", () => {
+      const csv = generateCSV([]);
+      expect(csv).toEqual('data:text/csv;charset=utf-8,');
+    });
+
+    it("shouldn't error if the table is undefined", () => {
+      const csv = generateCSV();
+      expect(csv).toEqual('data:text/csv;charset=utf-8,');
+    });
+
+    it('should surround data in double quotes to escape commas in content', () => {
+      const test1 = 'test';
+      const test2 = 'test,test';
+      const test3 = 'test,test,test';
+      const csv = generateCSV([[test1, test2, test3]]);
+      const contentArray = csv.split('"');
+      expect(contentArray[1]).toEqual(test1);
+      expect(contentArray[3]).toEqual(test2);
+      expect(contentArray[5]).toEqual(test3);
+    });
+
+    it('should break table onto multiple lines', () => {
+      const csv = generateCSV([['test'], ['test'], ['test']]);
+      const splitString = csv.split(/\r?\n/);
+      expect(splitString.length).toEqual(4);
+    });
+  });
+});

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -1,0 +1,15 @@
+export const generateCSV = (table = []) =>
+  table.reduce(
+    (csvString, infoArray) =>
+      `${csvString}${infoArray.map(item => `"${item}"`).join(',')}\n`,
+    'data:text/csv;charset=utf-8,',
+  );
+
+export const createCSVDownload = (csvContent, fileName = 'data') => {
+  const encodedUri = encodeURI(csvContent);
+  const link = document.createElement('a');
+  link.setAttribute('href', encodedUri);
+  link.setAttribute('download', `${fileName}.csv`);
+  document.body.appendChild(link); // Required for FF
+  link.click();
+};


### PR DESCRIPTION
## Description

Resolves #56 

You can download the CSV table of the entity you are viewing in the sector overview from the header in the tip right (as shown in the image).

<img width="1437" alt="screen shot 2018-03-13 at 8 21 52 am" src="https://user-images.githubusercontent.com/3017491/37344265-e979fc7a-2697-11e8-875f-422bc9f517f5.png">

Once downloaded you can open in Excel or Numbers as shown in the next image.
<img width="741" alt="screen shot 2018-03-13 at 8 23 12 am" src="https://user-images.githubusercontent.com/3017491/37344281-f6447b10-2697-11e8-87a0-4ac2314d1680.png">
