### PR TITLE
Hide Children Entities in Overview Lists

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1007,7 +1007,7 @@
   "tags.localTech.complications.0": "The tech is unreliable",
   "tags.localTech.complications.1": "The tech only works on this world",
   "tags.localTech.complications.2":
-    "The tech hs poorly-understood side effects",
+    "The tech has poorly-understood side effects",
   "tags.localTech.complications.3": "The tech is alien in nature",
   "tags.localTech.things.0": "The tech itself",
   "tags.localTech.things.1": "An unclaimed payment for a large shipment",
@@ -1861,8 +1861,7 @@
   "tags.ritualCombat.complications.2":
     "Loss doesn't mean death but it does mean ritual scarring or property loss",
   "tags.ritualCombat.things.0": "Magnificent weapon",
-  "tags.rThe world has a great many robots on it. Most bots are going to be non-sentient expert systems, though an AI with enough computing resources can control many bots at once, and some worlds may have developed VIs to a degree that individual bots can seem (or be) sentient. Some worlds might even be ruled by metal overlords, ones which do not need to be sentient so long as they have overwhelming force.itualCombat.things.1":
-    "Secret book of martial techniques",
+  "tags.ritualCombat.things.1": "Secret book of martial techniques",
   "tags.ritualCombat.things.2":
     "Token signifying immunity to ritual combat challenges",
   "tags.ritualCombat.things.3": "Prize won in bloody battle",
@@ -2470,7 +2469,7 @@
   "entity.moonBase.occupation.military": "Military listening post",
   "entity.moonBase.occupation.miners": "Lonely overseers and robot miners",
   "entity.moonBase.situation.dark": "Something dark has awoken",
-  "entity.moonBase.situation.criminals": "Cirminals trying to take over",
+  "entity.moonBase.situation.criminals": "Criminals trying to take over",
   "entity.moonBase.situation.plague": "Moon plague breaking out",
   "entity.moonBase.situation.supplies": "Desperate for vital supplies",
   "entity.moonBase.situation.rich": "Rich but badly-protected",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -2036,7 +2036,7 @@
   "tags.ritualCombat.complications.2":
     "La défaite n'entraine pas la mort, mais la perte de propriété ou une scarification rituelle",
   "tags.ritualCombat.things.0": "Arme magnifique",
-  "tags.rThe world has a great many robots on it. Most bots are going to be non-sentient expert systems, though an AI with enough computing resources can control many bots at once, and some worlds may have developed VIs to a degree that individual bots can seem (or be) sentient. Some worlds might even be ruled by metal overlords, ones which do not need to be sentient so long as they have overwhelming force.itualCombat.things.1":
+  "tags.ritualCombat.things.1":
     "Livre secret détaillant des techniques martiales",
   "tags.ritualCombat.things.2":
     "Jeton interdisant de mettre son porteur au défi de combattre rituellement",

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -83,7 +83,7 @@ export const getCurrentTopLevelEntities = createDeepEqualSelector(
 export const getCurrentEntities = createDeepEqualSelector(
   [currentSectorSelector, entitySelector, isViewingSharedSector],
   (currentSector, entities, isShared) =>
-    mapValues(entities, (entityList, entityType) =>
+    mapValues(entities, entityList =>
       pickBy(entityList, (entity, entityId) => {
         if (entity.sector !== currentSector && entityId !== currentSector) {
           return false;

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -83,13 +83,21 @@ export const getCurrentTopLevelEntities = createDeepEqualSelector(
 export const getCurrentEntities = createDeepEqualSelector(
   [currentSectorSelector, entitySelector, isViewingSharedSector],
   (currentSector, entities, isShared) =>
-    mapValues(entities, entityList =>
-      pickBy(
-        entityList,
-        ({ sector, isHidden }, entityId) =>
-          (sector === currentSector || entityId === currentSector) &&
-          (!isShared || !isHidden),
-      ),
+    mapValues(entities, (entityList, entityType) =>
+      pickBy(entityList, (entity, entityId) => {
+        if (entity.sector !== currentSector && entityId !== currentSector) {
+          return false;
+        }
+        let { isHidden } = entity;
+        let currentEntity = entity;
+        while (!isHidden && currentEntity) {
+          isHidden = currentEntity.isHidden; // eslint-disable-line
+          currentEntity = (entities[currentEntity.parentEntity] || {})[
+            currentEntity.parent
+          ];
+        }
+        return !isShared || !isHidden;
+      }),
     ),
 );
 

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -87,6 +87,8 @@ export const getCurrentEntities = createDeepEqualSelector(
       pickBy(entityList, (entity, entityId) => {
         if (entity.sector !== currentSector && entityId !== currentSector) {
           return false;
+        } else if (!isShared) {
+          return true;
         }
         let { isHidden } = entity;
         let currentEntity = entity;
@@ -96,7 +98,7 @@ export const getCurrentEntities = createDeepEqualSelector(
             currentEntity.parent
           ];
         }
-        return !isShared || !isHidden;
+        return !isHidden;
       }),
     ),
 );


### PR DESCRIPTION
Any child entities of hidden entities actually show up in the entity overview lists (oops!).

A couple translations misspellings and errors were fixed as well.