### PR TITLE
Hide World Tags For Players

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,9 +1,13 @@
 {
+  "4.4.0": {
+    "description": "Hide world tags by default to players.",
+    "date": "4-27-2018"
+  },
   "4.3.5": {
     "description":
       "Hide children entities of hidden parents in overview lists.",
     "date": "4-24-2018",
-    "changelog": [
+    "changes": [
       "Fix misspelling in local tech world tags.",
       "Fix missing ritual combat things translation.",
       "Fix moon base situation misspelling."

--- a/src/components/overview-table/index.js
+++ b/src/components/overview-table/index.js
@@ -5,11 +5,13 @@ import {
   getPrintableEntities,
   getCurrentSector,
 } from 'store/selectors/entity.selectors';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import OverviewTable from './overview-table';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
   currentSector: getCurrentSector(state),
+  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(connect(mapStateToProps)(OverviewTable));

--- a/src/components/overview-table/overview-table.js
+++ b/src/components/overview-table/overview-table.js
@@ -21,6 +21,7 @@ export default function OverviewTable({
   routeParams,
   currentSector,
   intl,
+  isShared,
 }) {
   const pluralName = intl.formatMessage({
     id: Pluralize(Entities[routeParams.entityType].name),
@@ -70,7 +71,7 @@ export default function OverviewTable({
         columns.push({ accessor: key, Header: name, translateItem: true });
       });
     }
-    if (Entities[entityType].tags) {
+    if (Entities[entityType].tags && !isShared) {
       columns.push({
         accessor: 'tags',
         Header: 'misc.tags',
@@ -160,6 +161,7 @@ OverviewTable.propTypes = {
     entityType: PropTypes.string.isRequired,
   }).isRequired,
   intl: intlShape.isRequired,
+  isShared: PropTypes.bool.isRequired,
 };
 
 OverviewTable.defaultProps = {

--- a/src/components/printables/condensed-printable/condensed-printable.js
+++ b/src/components/printables/condensed-printable/condensed-printable.js
@@ -23,6 +23,7 @@ export default class CondensedPrintable extends Component {
     }).isRequired,
     intl: intlShape.isRequired,
     endPrint: PropTypes.func.isRequired,
+    isShared: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -66,7 +67,7 @@ export default class CondensedPrintable extends Component {
         columns.push({ accessor: key, Header: name, translateItem: true });
       });
     }
-    if (Entities[entityType].tags) {
+    if (Entities[entityType].tags && !this.props.isShared) {
       columns.push({
         accessor: 'tags',
         Header: 'misc.tags',

--- a/src/components/printables/condensed-printable/index.js
+++ b/src/components/printables/condensed-printable/index.js
@@ -3,10 +3,12 @@ import { injectIntl } from 'react-intl';
 
 import { endPrint } from 'store/actions/sector.actions';
 import { getPrintableEntities } from 'store/selectors/entity.selectors';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import CondensedPrintable from './condensed-printable';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
+  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(

--- a/src/components/printables/expanded-printable/expanded-printable.js
+++ b/src/components/printables/expanded-printable/expanded-printable.js
@@ -21,6 +21,7 @@ export default class ExpandedPrintable extends Component {
     }).isRequired,
     intl: intlShape.isRequired,
     endPrint: PropTypes.func.isRequired,
+    isShared: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -34,7 +35,7 @@ export default class ExpandedPrintable extends Component {
     const conf = Entities[entityType];
 
     const blockAttributes = [];
-    if (entity.tags) {
+    if (entity.tags && !this.props.isShared) {
       blockAttributes.push(
         <div key="tags">
           <b>

--- a/src/components/printables/expanded-printable/index.js
+++ b/src/components/printables/expanded-printable/index.js
@@ -3,10 +3,12 @@ import { injectIntl } from 'react-intl';
 
 import { endPrint } from 'store/actions/sector.actions';
 import { getPrintableEntities } from 'store/selectors/entity.selectors';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import ExpendedPrintable from './expanded-printable';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
+  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
@@ -48,6 +48,7 @@ export default function EntityAttributes({
   toggleTagsOpen,
   isAncestorHidden,
   intl,
+  isShared,
 }) {
   const noAttributes =
     !entity.attributes || !Object.keys(entity.attributes).length;
@@ -192,6 +193,10 @@ export default function EntityAttributes({
     );
   }
 
+  if (isShared) {
+    return attributesSection;
+  }
+
   return [
     attributesSection,
     <EntityTags
@@ -220,6 +225,7 @@ EntityAttributes.propTypes = {
   toggleTagsOpen: PropTypes.func.isRequired,
   isAncestorHidden: PropTypes.bool.isRequired,
   intl: intlShape.isRequired,
+  isShared: PropTypes.bool.isRequired,
 };
 
 EntityAttributes.defaultProps = {

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/index.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/index.js
@@ -9,6 +9,7 @@ import {
 } from 'store/selectors/entity.selectors';
 import { isSidebarEditActiveSelector } from 'store/selectors/base.selectors';
 import { updateEntityInEdit } from 'store/actions/sidebar-edit.actions';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 
 import EntityAttributes from './entity-attributes';
 
@@ -18,6 +19,7 @@ const mapStateToProps = state => ({
   entityType: getCurrentEntityType(state),
   isSidebarEditActive: isSidebarEditActiveSelector(state),
   isAncestorHidden: isAncestorHidden(state),
+  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(

--- a/src/components/sidebar-entities/default-sidebar/entity-list/entity-list.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-list/entity-list.js
@@ -30,6 +30,7 @@ const EntityList = ({
   isOpen,
   toggleListOpen,
   intl,
+  isShared,
 }) => {
   const numEntities = size(entities);
   if (!numEntities && !isSidebarEditActive) {
@@ -141,16 +142,20 @@ const EntityList = ({
           ? coordinateKey(entity.x, entity.y)
           : entity.name;
       }
+      let additional;
+      if (Entities[entityType].topLevel) {
+        additional = coordinateKey(entity.x, entity.y);
+      } else if (!isShared) {
+        additional = ((entity.attributes || {}).tags || [])
+          .map(tag => intl.formatMessage({ id: `tags.${tag}` }))
+          .map(toCommaArray)
+          .join('');
+      }
       return {
         ...entity,
         sort,
         entityId: key,
-        additional: Entities[entityType].topLevel
-          ? coordinateKey(entity.x, entity.y)
-          : ((entity.attributes || {}).tags || [])
-              .map(tag => intl.formatMessage({ id: `tags.${tag}` }))
-              .map(toCommaArray)
-              .join(''),
+        additional,
       };
     })
       .sort(sortByKey('sort'))
@@ -177,6 +182,7 @@ EntityList.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggleListOpen: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  isShared: PropTypes.bool.isRequired,
 };
 
 EntityList.defaultProps = {

--- a/src/components/sidebar-entities/default-sidebar/entity-list/index.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-list/index.js
@@ -6,12 +6,14 @@ import {
   sidebarEditChildrenSelector,
 } from 'store/selectors/base.selectors';
 import { createChildInEdit } from 'store/actions/sidebar-edit.actions';
+import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 
 import EntityList from './entity-list';
 
 const mapStateToProps = (state, props) => ({
   isSidebarEditActive: isSidebarEditActiveSelector(state),
   editableEntities: sidebarEditChildrenSelector(state)[props.entityType],
+  isShared: isViewingSharedSector(state),
 });
 
 const mapDispatchToProps = (dispatch, props) => ({


### PR DESCRIPTION
## Description

I should have done this a long time ago. Tags will no longer show up in the overview, sector sidebar, or printables to players you have shared the sector to. The ability to [toggle this visibility](https://github.com/mpigsley/sectors-without-number/issues/85) is still an open ticket.

Resolves #135