### PR TITLE
Attribute & Tag Visibility Toggles

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -4,7 +4,8 @@
     "date": "4-29-2018",
     "changes": [
       "Add option in configuration to hide all tags upon generation.",
-      "Hidden attributes & tags are hidden in overview & printables from planets."
+      "Hidden attributes & tags are hidden in overview & printables from planets.",
+      "Updates planet generator to always generate at least one planet in all cases"
     ]
   },
   "4.4.0": {

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,4 +1,12 @@
 {
+  "4.5.0": {
+    "description": "Allow attribute and tag visibility to be toggled.",
+    "date": "4-29-2018",
+    "changes": [
+      "Add option in configuration to hide all tags upon generation.",
+      "Hidden attributes & tags are hidden in overview & printables from planets."
+    ]
+  },
   "4.4.0": {
     "description": "Hide world tags by default to players.",
     "date": "4-27-2018"

--- a/src/components/configure/configure.js
+++ b/src/components/configure/configure.js
@@ -25,6 +25,7 @@ export default function Configure({
   updateConfiguration,
   generateSector,
   isBuilder,
+  hideTags,
   columns,
   rows,
   name,
@@ -120,6 +121,12 @@ export default function Configure({
           onChange={updateInput}
           label={intl.formatMessage({ id: 'misc.useAPOI' })}
         />
+        <Checkbox
+          data-key="hideTags"
+          value={hideTags}
+          onChange={updateInput}
+          label={intl.formatMessage({ id: 'misc.hideTagsFromPlayers' })}
+        />
       </SubContainer>
       <SubContainer
         className="Configure-PaddedButtons"
@@ -141,6 +148,7 @@ Configure.propTypes = {
   updateConfiguration: PropTypes.func.isRequired,
   generateSector: PropTypes.func.isRequired,
   isBuilder: PropTypes.bool.isRequired,
+  hideTags: PropTypes.bool.isRequired,
   columns: PropTypes.number,
   rows: PropTypes.number,
   name: PropTypes.string,

--- a/src/components/overview-table/index.js
+++ b/src/components/overview-table/index.js
@@ -5,13 +5,11 @@ import {
   getPrintableEntities,
   getCurrentSector,
 } from 'store/selectors/entity.selectors';
-import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import OverviewTable from './overview-table';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
   currentSector: getCurrentSector(state),
-  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(connect(mapStateToProps)(OverviewTable));

--- a/src/components/overview-table/overview-table.js
+++ b/src/components/overview-table/overview-table.js
@@ -21,7 +21,6 @@ export default function OverviewTable({
   routeParams,
   currentSector,
   intl,
-  isShared,
 }) {
   const pluralName = intl.formatMessage({
     id: Pluralize(Entities[routeParams.entityType].name),
@@ -71,12 +70,14 @@ export default function OverviewTable({
         columns.push({ accessor: key, Header: name, translateItem: true });
       });
     }
-    if (Entities[entityType].tags && !isShared) {
+    if (Entities[entityType].tags) {
       columns.push({
         accessor: 'tags',
         Header: 'misc.tags',
         Cell: tags =>
-          tags.map(tag => intl.formatMessage({ id: `tags.${tag}` })).join(', '),
+          tags
+            .map(tag => intl.formatMessage({ id: `tags.${tag}` }))
+            .join(', ') || '-',
       });
     }
     return columns;
@@ -161,7 +162,6 @@ OverviewTable.propTypes = {
     entityType: PropTypes.string.isRequired,
   }).isRequired,
   intl: intlShape.isRequired,
-  isShared: PropTypes.bool.isRequired,
 };
 
 OverviewTable.defaultProps = {

--- a/src/components/printables/condensed-printable/condensed-printable.js
+++ b/src/components/printables/condensed-printable/condensed-printable.js
@@ -23,7 +23,6 @@ export default class CondensedPrintable extends Component {
     }).isRequired,
     intl: intlShape.isRequired,
     endPrint: PropTypes.func.isRequired,
-    isShared: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -67,14 +66,14 @@ export default class CondensedPrintable extends Component {
         columns.push({ accessor: key, Header: name, translateItem: true });
       });
     }
-    if (Entities[entityType].tags && !this.props.isShared) {
+    if (Entities[entityType].tags) {
       columns.push({
         accessor: 'tags',
         Header: 'misc.tags',
         Cell: tags =>
           tags
             .map(tag => this.props.intl.formatMessage({ id: `tags.${tag}` }))
-            .join(', '),
+            .join(', ') || '-',
       });
     }
     return columns;

--- a/src/components/printables/condensed-printable/index.js
+++ b/src/components/printables/condensed-printable/index.js
@@ -3,12 +3,10 @@ import { injectIntl } from 'react-intl';
 
 import { endPrint } from 'store/actions/sector.actions';
 import { getPrintableEntities } from 'store/selectors/entity.selectors';
-import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import CondensedPrintable from './condensed-printable';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
-  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(

--- a/src/components/printables/expanded-printable/expanded-printable.js
+++ b/src/components/printables/expanded-printable/expanded-printable.js
@@ -21,7 +21,6 @@ export default class ExpandedPrintable extends Component {
     }).isRequired,
     intl: intlShape.isRequired,
     endPrint: PropTypes.func.isRequired,
-    isShared: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -35,7 +34,7 @@ export default class ExpandedPrintable extends Component {
     const conf = Entities[entityType];
 
     const blockAttributes = [];
-    if (entity.tags && !this.props.isShared) {
+    if (entity.tags && entity.tags.length) {
       blockAttributes.push(
         <div key="tags">
           <b>

--- a/src/components/printables/expanded-printable/index.js
+++ b/src/components/printables/expanded-printable/index.js
@@ -3,12 +3,10 @@ import { injectIntl } from 'react-intl';
 
 import { endPrint } from 'store/actions/sector.actions';
 import { getPrintableEntities } from 'store/selectors/entity.selectors';
-import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import ExpendedPrintable from './expanded-printable';
 
 const mapStateToProps = state => ({
   entities: getPrintableEntities(state),
-  isShared: isViewingSharedSector(state),
 });
 
 export default injectIntl(

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
@@ -4,6 +4,7 @@ import ReactHintFactory from 'react-hint';
 import { omit, map, values, pickBy, size } from 'lodash';
 import { RefreshCw, EyeOff } from 'react-feather';
 import { FormattedMessage, intlShape } from 'react-intl';
+import classNames from 'classnames';
 
 import FlexContainer from 'primitives/container/flex-container';
 import SectionHeader from 'primitives/text/section-header';
@@ -133,7 +134,12 @@ export default function EntityAttributes({
       }
 
       return (
-        <FlexContainer key={key} className="EntityAttributes-Attribute">
+        <FlexContainer
+          key={key}
+          className={classNames('EntityAttributes-Attribute', {
+            'EntityAttributes-Attribute--hidden': visibility === false,
+          })}
+        >
           <b className="EntityAttributes-Header">
             <FormattedMessage id={name} />:
           </b>

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
@@ -34,7 +34,9 @@ export default function EntityAttributes({
   isShared,
 }) {
   const hiddenAttributes = isShared
-    ? Object.keys(pickBy(entity.visibility, vision => vision === false))
+    ? Object.keys(pickBy(entity.visibility, vision => vision === false)).map(
+        key => key.replace('attr.', ''),
+      )
     : [];
   const allAttributes = omit(entity.attributes, hiddenAttributes);
   const noAttributes = !entity.attributes || !size(allAttributes);
@@ -184,13 +186,16 @@ export default function EntityAttributes({
         <Input
           className="EntityAttributes-Checkbox"
           checked={
-            (entity.visibility || {})[key] === undefined
+            (entity.visibility || {})[`attr.${key}`] === undefined
               ? false
-              : !(entity.visibility || {})[key]
+              : !(entity.visibility || {})[`attr.${key}`]
           }
           onChange={({ target }) =>
             updateEntityInEdit({
-              visibility: { ...entity.visibility, [key]: !target.checked },
+              visibility: {
+                ...entity.visibility,
+                [`attr.${key}`]: !target.checked,
+              },
             })
           }
           type="checkbox"
@@ -210,7 +215,7 @@ export default function EntityAttributes({
             (isSidebarEditActive ? renderAttributeEdit : renderAttribute)(
               attribute,
               (entity.attributes || {})[attribute.key],
-              (entity.visibility || {})[attribute.key],
+              (entity.visibility || {})[`attr.${attribute.key}`],
             ),
           )}
           {hiddenAttribute}
@@ -264,6 +269,7 @@ export default function EntityAttributes({
         isOpen={isTagsOpen}
         toggleOpen={toggleTagsOpen}
         intl={intl}
+        isShared={isShared}
       />
       <ReactHint events position="left" />
     </Fragment>

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-attributes.js
@@ -192,10 +192,7 @@ export default function EntityAttributes({
           }
           onChange={({ target }) =>
             updateEntityInEdit({
-              visibility: {
-                ...entity.visibility,
-                [`attr.${key}`]: !target.checked,
-              },
+              visibility: { [`attr.${key}`]: !target.checked },
             })
           }
           type="checkbox"

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-tags.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-tags.js
@@ -61,6 +61,7 @@ export default function EntityTags({
           onClick={() =>
             updateEntityInEdit({
               attributes: { tags: pull(entityTags, tag) },
+              visibility: { [`tag.${tag}`]: undefined },
             })
           }
         />

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/style.scss
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/style.scss
@@ -71,3 +71,17 @@
 .EntityAttributes-Name {
   cursor: pointer;
 }
+
+.EntityAttributes-Checkbox {
+  margin-left: 0.5rem;
+  margin-right: 0;
+}
+
+.EntityAttributes-SubHeader {
+  color: $light2;
+  margin: 0 1rem;
+}
+
+.EntityAttributes-SubHeaderHidden {
+  margin: 0rem 0.1rem 0 0.5rem;
+}

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/style.scss
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/style.scss
@@ -28,6 +28,10 @@
   color: $light2;
   font-size: 0.9rem;
   padding: 0.2rem 0;
+
+  &--hidden {
+    color: $light1;
+  }
 }
 
 .EntityAttributes-Header {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2589,6 +2589,7 @@
   "misc.forgotPassword": "Forgot Password?",
   "misc.friends": "Friends",
   "misc.generate": "Generate",
+  "misc.hideTagsFromPlayers": "Hide Tags from Players",
   "misc.home": "Home",
   "misc.initializeEmpty": "Initialize Empty Sector",
   "misc.isHidden": "Is Hidden",

--- a/src/lang/sv.json
+++ b/src/lang/sv.json
@@ -282,6 +282,7 @@
   "misc.haveNumSectors": "Du har minst {num} sektorer.",
   "misc.copiedLinkTo": "Du har kopierat en länk direkt till denna {entity}.",
   "misc.receiveEmail": "Du kommer snart få ett email.",
+  "misc.successfullyRemoved": "{entity} har tagis bort.",
   "misc.sectorsSynced":
     "Dina sektorer har synkroniserats. Du kan nu dela dem med dina vänner.",
   "misc.windowTooSmall":

--- a/src/primitives/other/table/index.js
+++ b/src/primitives/other/table/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { injectIntl, intlShape } from 'react-intl';
 import { ChevronDown, ChevronUp } from 'react-feather';
+import { isNil } from 'lodash';
 
 import './style.css';
 
@@ -99,9 +100,10 @@ class Table extends Component {
 
   renderRowItem(row, { Cell, accessor, translateItem }) {
     let item = row[accessor];
-    if (translateItem && this.props.intl.messages[row[accessor]]) {
+    if (item && translateItem && this.props.intl.messages[row[accessor]]) {
       item = this.props.intl.formatMessage({ id: row[accessor] });
     }
+    item = isNil(item) ? '-' : item;
     return Cell ? Cell(item, row) : item;
   }
 

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -17,6 +17,7 @@ import {
   getCurrentEntityChildren,
 } from 'store/selectors/entity.selectors';
 import {
+  sidebarEditEntitySelector,
   sidebarEditChildrenSelector,
   syncLockSelector,
 } from 'store/selectors/base.selectors';
@@ -49,7 +50,7 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
         attributes: entity.attributes
           ? { ...entity.attributes, tags: [...(entity.attributes.tags || [])] }
           : undefined,
-        visibility: entity.visibility,
+        visibility: entity.visibility || {},
         isHidden: entity.isHidden,
       },
       isNil,
@@ -86,13 +87,34 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
   });
 };
 
-export const updateEntityInEdit = updates => (dispatch, getState) => {
+export const updateEntityInEdit = changes => (dispatch, getState) => {
   const state = getState();
   if (syncLockSelector(state)) {
     return Promise.resolve();
   }
   const entityId = getCurrentEntityId(state);
   const entityType = getCurrentEntityType(state);
+  const entity = sidebarEditEntitySelector(state);
+  const updates = {
+    ...changes,
+    attributes: omitBy(
+      {
+        ...(entity.attributes || {}),
+        ...(changes.attributes || {}),
+      },
+      isNil,
+    ),
+    visibility: omitBy(
+      {
+        ...(entity.visibility || {}),
+        ...(changes.visibility || {}),
+      },
+      isNil,
+    ),
+  };
+
+  console.log(changes);
+
   return dispatch({
     type: UPDATE_ENTITY_IN_EDIT,
     entityId,

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -113,8 +113,6 @@ export const updateEntityInEdit = changes => (dispatch, getState) => {
     ),
   };
 
-  console.log(changes);
-
   return dispatch({
     type: UPDATE_ENTITY_IN_EDIT,
     entityId,

--- a/src/store/actions/sidebar-edit.actions.js
+++ b/src/store/actions/sidebar-edit.actions.js
@@ -49,6 +49,7 @@ export const activateSidebarEdit = () => (dispatch, getState) => {
         attributes: entity.attributes
           ? { ...entity.attributes, tags: [...(entity.attributes.tags || [])] }
           : undefined,
+        visibility: entity.visibility,
         isHidden: entity.isHidden,
       },
       isNil,

--- a/src/store/reducers/sector.reducers.js
+++ b/src/store/reducers/sector.reducers.js
@@ -38,6 +38,7 @@ const initialState = {
     name: Entities.sector.nameGenerator(),
     isBuilder: false,
     additionalPointsOfInterest: true,
+    hideTags: true,
     columns: COLUMNS,
     rows: ROWS,
   },

--- a/src/store/reducers/sidebar-edit.reducers.js
+++ b/src/store/reducers/sidebar-edit.reducers.js
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { omit, omitBy, isNil } from 'lodash';
 
 import {
   ACTIVATE_SIDEBAR_EDIT,
@@ -32,15 +32,14 @@ export default function sidebarEdit(state = initialState, action) {
     case UPDATE_ENTITY_IN_EDIT:
       return {
         ...state,
-        entity: {
-          ...state.entity,
-          ...action.updates,
-          attributes: {
-            ...state.entity.attributes,
-            ...action.updates.attributes,
+        entity: omitBy(
+          {
+            ...state.entity,
+            ...action.updates,
+            isUpdated: true,
           },
-          isUpdated: true,
-        },
+          isNil,
+        ),
       };
     case DELETE_CHILD_IN_EDIT: {
       let entityTypeList;

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -267,8 +267,9 @@ export const getPrintableEntities = createDeepEqualSelector(
     getEntityChildren,
     getEntityNeighbors,
     currentSectorSelector,
+    isViewingSharedSector,
   ],
-  (currentEntities, entityChildren, entityNeighbors, currentSector) =>
+  (currentEntities, entityChildren, entityNeighbors, currentSector, isShared) =>
     mapValues(
       pickBy(omit(currentEntities, Entities.sector.key), size),
       (entities, entityType) =>
@@ -282,8 +283,10 @@ export const getPrintableEntities = createDeepEqualSelector(
               (Entities[entityType].attributes || []).map(({ key }) => key),
               (Entities[entityType].attributes || []).map(
                 ({ key, attributes }) =>
-                  (attributes[(entity.attributes || {})[key]] || {}).name ||
-                  (entity.attributes || {})[key],
+                  isShared && (entity.visibility || {})[key] === false
+                    ? undefined
+                    : (attributes[(entity.attributes || {})[key]] || {}).name ||
+                      (entity.attributes || {})[key],
               ),
             ),
             tags: (entity.attributes || {}).tags || [],

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -283,13 +283,16 @@ export const getPrintableEntities = createDeepEqualSelector(
               (Entities[entityType].attributes || []).map(({ key }) => key),
               (Entities[entityType].attributes || []).map(
                 ({ key, attributes }) =>
-                  isShared && (entity.visibility || {})[key] === false
+                  isShared && (entity.visibility || {})[`attr.${key}`] === false
                     ? undefined
                     : (attributes[(entity.attributes || {})[key]] || {}).name ||
                       (entity.attributes || {})[key],
               ),
             ),
-            tags: (entity.attributes || {}).tags || [],
+            tags: ((entity.attributes || {}).tags || []).filter(
+              tag =>
+                !isShared || (entity.visibility || {})[`tag.${tag}`] !== false,
+            ),
             description: (entity.attributes || {}).description,
             key: entityId,
             name: entity.name,

--- a/src/utils/entity-generators/planet-generator.js
+++ b/src/utils/entity-generators/planet-generator.js
@@ -80,13 +80,7 @@ export const generatePlanet = ({
   return planet;
 };
 
-export const generatePlanets = ({
-  sector,
-  parent,
-  parentEntity,
-  additionalPointsOfInterest,
-  children,
-}) => {
+export const generatePlanets = ({ sector, parent, parentEntity, children }) => {
   if (!sector) {
     throw new Error('Sector id must be defined to generate planets');
   }

--- a/src/utils/entity-generators/planet-generator.js
+++ b/src/utils/entity-generators/planet-generator.js
@@ -97,12 +97,8 @@ export const generatePlanets = ({
   let numChildren = children;
   if (!numChildren) {
     const chance = new Chance();
-    if (additionalPointsOfInterest) {
-      if (parentEntity === Entities.blackHole.key) {
-        numChildren = [...Array(chance.weighted([0, 1], [15, 1]))];
-      } else {
-        numChildren = [...Array(chance.weighted([0, 1, 2, 3], [5, 15, 5, 2]))];
-      }
+    if (parentEntity === Entities.blackHole.key) {
+      numChildren = [...Array(chance.weighted([0, 1], [15, 1]))];
     } else {
       numChildren = [...Array(chance.weighted([1, 2, 3], [8, 3, 2]))];
     }

--- a/src/utils/entity-generators/planet-generator.js
+++ b/src/utils/entity-generators/planet-generator.js
@@ -1,4 +1,5 @@
 import Chance from 'chance';
+import { zipObject } from 'lodash';
 
 import { generateName } from 'utils/name-generator';
 import { worldTagKeys } from 'constants/world-tags';
@@ -15,6 +16,7 @@ export const generatePlanet = ({
   name = generateName(),
   generate = true,
   isHidden,
+  hideTags = false,
 } = {}) => {
   if (!sector) {
     throw new Error('Sector must be defined to generate a planet');
@@ -29,10 +31,17 @@ export const generatePlanet = ({
     planet = { ...planet, isHidden };
   }
   if (generate) {
+    const tags = chance.pickset(Object.keys(worldTagKeys), 2);
+    if (hideTags) {
+      planet.visibility = zipObject(
+        tags.map(tag => `tag.${tag}`),
+        tags.map(() => false),
+      );
+    }
     planet = {
       ...planet,
       attributes: {
-        tags: chance.pickset(Object.keys(worldTagKeys), 2),
+        tags,
         techLevel: `TL${chance.weighted(
           ['0', '1', '2', '3', '4', '4+', '5'],
           [1, 1, 2, 2, 3, 1, 1],
@@ -80,7 +89,13 @@ export const generatePlanet = ({
   return planet;
 };
 
-export const generatePlanets = ({ sector, parent, parentEntity, children }) => {
+export const generatePlanets = ({
+  sector,
+  parent,
+  parentEntity,
+  children,
+  hideTags,
+}) => {
   if (!sector) {
     throw new Error('Sector id must be defined to generate planets');
   }
@@ -106,6 +121,7 @@ export const generatePlanets = ({ sector, parent, parentEntity, children }) => {
         parentEntity,
         name,
         generate,
+        hideTags,
       }),
     ),
   };


### PR DESCRIPTION
## Description

Game masters can now turn off specific attributes and tags so that when the sector is shared with their players, they can't see them. Tag visibility is especially important. Any existing sector will not be converted to automatically hiding tags or attributes. For those game masters that would like to do this, you'll have to go through and update your planets individually.

Resolves #85 