### PR TITLE
Hide Occupation and Situation by Default

### DIFF
--- a/src/components/configure/configure.js
+++ b/src/components/configure/configure.js
@@ -24,6 +24,7 @@ export default function Configure({
   additionalPointsOfInterest,
   updateConfiguration,
   generateSector,
+  hideOccAndSit,
   isBuilder,
   hideTags,
   columns,
@@ -127,6 +128,12 @@ export default function Configure({
           onChange={updateInput}
           label={intl.formatMessage({ id: 'misc.hideTagsFromPlayers' })}
         />
+        <Checkbox
+          data-key="hideOccAndSit"
+          value={hideOccAndSit}
+          onChange={updateInput}
+          label={intl.formatMessage({ id: 'misc.hideOccAndSit' })}
+        />
       </SubContainer>
       <SubContainer
         className="Configure-PaddedButtons"
@@ -149,6 +156,7 @@ Configure.propTypes = {
   generateSector: PropTypes.func.isRequired,
   isBuilder: PropTypes.bool.isRequired,
   hideTags: PropTypes.bool.isRequired,
+  hideOccAndSit: PropTypes.bool.isRequired,
   columns: PropTypes.number,
   rows: PropTypes.number,
   name: PropTypes.string,

--- a/src/constants/language/cosmic-names.json
+++ b/src/constants/language/cosmic-names.json
@@ -1288,7 +1288,7 @@
   "Ahmood",
   "Khani",
   "Haqani",
-  "ali",
+  "Ali",
   "Hamadeg",
   "Bahhadu",
   "Husabet",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2607,6 +2607,7 @@
   "misc.haveNumSectors": "You have at least {num} sectors.",
   "misc.hexSystemText": "Hex System Text",
   "misc.hiddenParrent": "A parent entity is hiding this {entity}.",
+  "misc.hideOccAndSit": "Hide Occupation & Situation from Players",
   "misc.hideTagsFromPlayers": "Hide Tags from Players",
   "misc.home": "Home",
   "misc.initializeEmpty": "Initialize Empty Sector",

--- a/src/store/reducers/sector.reducers.js
+++ b/src/store/reducers/sector.reducers.js
@@ -38,6 +38,7 @@ const initialState = {
     name: Entities.sector.nameGenerator(),
     isBuilder: false,
     additionalPointsOfInterest: true,
+    hideOccAndSit: true,
     hideTags: true,
     columns: COLUMNS,
     rows: ROWS,

--- a/src/store/selectors/navigation.selectors.js
+++ b/src/store/selectors/navigation.selectors.js
@@ -8,6 +8,7 @@ import {
   navigationRoutesSelector,
   navigationSettingsSelector,
   isSharedSectorSelector,
+  savedSectorSelector,
 } from 'store/selectors/base.selectors';
 import { getAllTopLevelEntities } from 'store/selectors/entity.selectors';
 
@@ -50,6 +51,7 @@ export const getCurrentNavigationWithSettings = createSelector(
 );
 
 export const isFetchingCurrentNavigation = createSelector(
-  [fetchedNavigationSelector, currentSectorSelector],
-  (fetched, sector) => !includes(fetched, sector),
+  [fetchedNavigationSelector, savedSectorSelector, currentSectorSelector],
+  (fetched, saved, sector) =>
+    includes(saved, sector) && !includes(fetched, sector),
 );

--- a/src/utils/entity-generators/asteroid-base-generator.js
+++ b/src/utils/entity-generators/asteroid-base-generator.js
@@ -9,6 +9,7 @@ export const generateAsteroidBase = ({
   parent,
   parentEntity,
   name = generateStationName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateAsteroidBase = ({
     asteroidBase = { ...asteroidBase, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      asteroidBase.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     asteroidBase = {
       ...asteroidBase,
       attributes: {
@@ -44,6 +51,7 @@ export const generateAsteroidBases = ({
   parentEntity,
   children = [...Array(new Chance().weighted([0, 1, 2], [1, 3, 2]))],
   additionalPointsOfInterest,
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateAsteroidBases = ({
         parentEntity,
         name,
         generate,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/asteroid-belt-generator.js
+++ b/src/utils/entity-generators/asteroid-belt-generator.js
@@ -7,6 +7,7 @@ import Situation from 'constants/asteroid-belt/situation';
 export const generateAsteroidBelt = ({
   sector,
   name = generateAsteroidBeltName(),
+  hideOccAndSit = false,
   parent,
   parentEntity,
   generate = true,
@@ -25,6 +26,12 @@ export const generateAsteroidBelt = ({
     asteroidBelt = { ...asteroidBelt, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      asteroidBelt.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     asteroidBelt = {
       ...asteroidBelt,
       attributes: {
@@ -42,6 +49,7 @@ export const generateAsteroidBelts = ({
   parentEntity,
   children = [...Array(new Chance().weighted([0, 1], [4, 1]))],
   additionalPointsOfInterest,
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -61,6 +69,7 @@ export const generateAsteroidBelts = ({
         parentEntity,
         name,
         generate,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/deep-space-station-generator.js
+++ b/src/utils/entity-generators/deep-space-station-generator.js
@@ -7,6 +7,7 @@ import Situation from 'constants/space-station/situation';
 export const generateDeepSpaceStation = ({
   sector,
   name = generateStationName(),
+  hideOccAndSit = false,
   parent,
   parentEntity,
   generate = true,
@@ -27,6 +28,12 @@ export const generateDeepSpaceStation = ({
     station = { ...station, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      station.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     station = {
       ...station,
       attributes: {
@@ -44,6 +51,7 @@ export const generateDeepSpaceStations = ({
   parentEntity,
   children = [...Array(new Chance().weighted([0, 1], [3, 1]))],
   additionalPointsOfInterest,
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -65,6 +73,7 @@ export const generateDeepSpaceStations = ({
         parentEntity,
         name,
         generate,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/gas-giant-mine-generator.js
+++ b/src/utils/entity-generators/gas-giant-mine-generator.js
@@ -9,6 +9,7 @@ export const generateGasGiantMine = ({
   parent,
   parentEntity,
   name = generateMineName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateGasGiantMine = ({
     gasGiantMine = { ...gasGiantMine, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      gasGiantMine.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     gasGiantMine = {
       ...gasGiantMine,
       attributes: {
@@ -44,6 +51,7 @@ export const generateGasGiantMines = ({
   parentEntity,
   children = [...Array(new Chance().weighted([0, 1, 2], [8, 3, 1]))],
   additionalPointsOfInterest,
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateGasGiantMines = ({
         parentEntity,
         name,
         generate,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/moon-base-generator.js
+++ b/src/utils/entity-generators/moon-base-generator.js
@@ -9,6 +9,7 @@ export const generateMoonBase = ({
   parent,
   parentEntity,
   name = generateStationName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateMoonBase = ({
     asteroidBase = { ...asteroidBase, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      asteroidBase.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     asteroidBase = {
       ...asteroidBase,
       attributes: {
@@ -44,6 +51,7 @@ export const generateMoonBases = ({
   parentEntity,
   additionalPointsOfInterest,
   children = [...Array(new Chance().weighted([0, 1], [5, 2]))],
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -61,6 +69,7 @@ export const generateMoonBases = ({
         sector,
         parent,
         parentEntity,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/orbital-ruin-generator.js
+++ b/src/utils/entity-generators/orbital-ruin-generator.js
@@ -9,6 +9,7 @@ export const generateOrbitalRuin = ({
   parent,
   parentEntity,
   name = generateStationName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateOrbitalRuin = ({
     orbitalRuin = { ...orbitalRuin, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      orbitalRuin.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     orbitalRuin = {
       ...orbitalRuin,
       attributes: {
@@ -44,6 +51,7 @@ export const generateOrbitalRuins = ({
   parentEntity,
   children = [...Array(new Chance().weighted([0, 1], [3, 1]))],
   additionalPointsOfInterest,
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateOrbitalRuins = ({
         parentEntity,
         name,
         generate,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/refueling-station-generator.js
+++ b/src/utils/entity-generators/refueling-station-generator.js
@@ -9,6 +9,7 @@ export const generateRefuelingStation = ({
   parent,
   parentEntity,
   name = generateStationName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateRefuelingStation = ({
     refuelingStation = { ...refuelingStation, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      refuelingStation.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     refuelingStation = {
       ...refuelingStation,
       attributes: {
@@ -44,6 +51,7 @@ export const generateRefuelingStations = ({
   parentEntity,
   additionalPointsOfInterest,
   children = [...Array(new Chance().weighted([0, 1], [3, 1]))],
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateRefuelingStations = ({
         sector,
         parent,
         parentEntity,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/research-base-generator.js
+++ b/src/utils/entity-generators/research-base-generator.js
@@ -9,6 +9,7 @@ export const generateResearchBase = ({
   parent,
   parentEntity,
   name = generateStationName(),
+  hideOccAndSit = false,
   generate = true,
   isHidden,
 } = {}) => {
@@ -27,6 +28,12 @@ export const generateResearchBase = ({
     researchBase = { ...researchBase, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      researchBase.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     researchBase = {
       ...researchBase,
       attributes: {
@@ -44,6 +51,7 @@ export const generateResearchBases = ({
   parentEntity,
   additionalPointsOfInterest,
   children = [...Array(new Chance().weighted([0, 1], [3, 1]))],
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateResearchBases = ({
         sector,
         parent,
         parentEntity,
+        hideOccAndSit,
       }),
     ),
   };

--- a/src/utils/entity-generators/space-station-generator.js
+++ b/src/utils/entity-generators/space-station-generator.js
@@ -6,6 +6,7 @@ import Situation from 'constants/space-station/situation';
 
 export const generateSpaceStation = ({
   name = generateStationName(),
+  hideOccAndSit = false,
   sector,
   parent,
   parentEntity,
@@ -27,6 +28,12 @@ export const generateSpaceStation = ({
     station = { ...station, isHidden };
   }
   if (generate) {
+    if (hideOccAndSit) {
+      station.visibility = {
+        'attr.occupation': false,
+        'attr.situation': false,
+      };
+    }
     station = {
       ...station,
       attributes: {
@@ -44,6 +51,7 @@ export const generateSpaceStations = ({
   parentEntity,
   additionalPointsOfInterest,
   children = [...Array(new Chance().weighted([0, 1, 2], [3, 1, 1]))],
+  hideOccAndSit,
 }) => {
   if (!additionalPointsOfInterest) {
     return { children: [] };
@@ -63,6 +71,7 @@ export const generateSpaceStations = ({
         sector,
         parent,
         parentEntity,
+        hideOccAndSit,
       }),
     ),
   };


### PR DESCRIPTION
## Description

There is now a configuration option to toggle this. It's set up exactly like the planet tags auto-hiding.

Resolves #146 