### PR TITLE
Enable Multiple Selected Layers

### DIFF
--- a/src/components/entity-tooltips/entity-tooltips.js
+++ b/src/components/entity-tooltips/entity-tooltips.js
@@ -3,23 +3,28 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import FlexContainer from 'primitives/container/flex-container';
-import { map } from 'constants/lodash';
+import { map, size } from 'constants/lodash';
 
 import './style.scss';
 
-export default function EntityTooltips({ hoverKey, holdKey, layer, hexes }) {
+export default function EntityTooltips({
+  hoverKey,
+  holdKey,
+  hexLayerNames,
+  hexes,
+}) {
   const renderTooltip = system => {
     let hexLayerRegions;
-    const hexLayer = (layer.hexes || {})[system.hexKey];
-    if (((hexLayer || {}).regions || []).length) {
-      const regionNames = map(
-        hexLayer.regions,
-        region => layer.regions[region].name,
-      ).join(', ');
+    const hexLayer = hexLayerNames[system.hexKey];
+    if (size(hexLayer)) {
       hexLayerRegions = (
-        <span className="EntityTooltips-Regions">
-          <b>{layer.name}:</b> {regionNames}
-        </span>
+        <FlexContainer direction="column" className="EntityTooltips-Regions">
+          {map(hexLayer, (names, layerName) => (
+            <span key={layerName}>
+              <b>{layerName}:</b> {names.join(', ')}
+            </span>
+          ))}
+        </FlexContainer>
       );
     }
     return (
@@ -53,11 +58,7 @@ export default function EntityTooltips({ hoverKey, holdKey, layer, hexes }) {
 EntityTooltips.propTypes = {
   hoverKey: PropTypes.string,
   holdKey: PropTypes.string,
-  layer: PropTypes.shape({
-    name: PropTypes.string,
-    hexes: PropTypes.shape(),
-    regions: PropTypes.shape(),
-  }).isRequired,
+  hexLayerNames: PropTypes.shape().isRequired,
   hexes: PropTypes.arrayOf(
     PropTypes.shape({
       hexKey: PropTypes.string,

--- a/src/components/entity-tooltips/index.js
+++ b/src/components/entity-tooltips/index.js
@@ -5,13 +5,13 @@ import {
   holdKeySelector,
   hoverKeySelector,
 } from 'store/selectors/base.selectors';
-import { visibleLayer } from 'store/selectors/layer.selectors';
+import { hexLayerNameMapping } from 'store/selectors/layer.selectors';
 import EntityTooltips from './entity-tooltips';
 
 const mapStateToProps = createStructuredSelector({
   holdKey: holdKeySelector,
   hoverKey: hoverKeySelector,
-  layer: visibleLayer,
+  hexLayerNames: hexLayerNameMapping,
 });
 
 export default connect(mapStateToProps)(EntityTooltips);

--- a/src/components/sidebar-entities/layer-sidebar/index.js
+++ b/src/components/sidebar-entities/layer-sidebar/index.js
@@ -8,7 +8,7 @@ import {
   layerRegionFormSelector,
   layerColorPickerSelector,
 } from 'store/selectors/base.selectors';
-import { visibleLayer } from 'store/selectors/layer.selectors';
+import { visibleLayers } from 'store/selectors/layer.selectors';
 import { isViewingSharedSector } from 'store/selectors/sector.selectors';
 import {
   initializeRegionForm,
@@ -19,7 +19,7 @@ import {
 import LayerSidebar from './layer-sidebar';
 
 const mapStateToProps = createStructuredSelector({
-  layer: visibleLayer,
+  layers: visibleLayers,
   layerId: currentEntitySelector,
   isEditing: layerIsEditingSelector,
   regionForm: layerRegionFormSelector,

--- a/src/components/sidebar-entities/layer-sidebar/layer-sidebar.js
+++ b/src/components/sidebar-entities/layer-sidebar/layer-sidebar.js
@@ -20,12 +20,14 @@ const ReactHint = ReactHintFactory(React);
 export default class LayerSidebar extends Component {
   static propTypes = {
     intl: intlShape.isRequired,
-    layer: PropTypes.shape({
-      description: PropTypes.string,
-      isHidden: PropTypes.bool,
-      regions: PropTypes.shape(),
-      name: PropTypes.string,
-    }),
+    layers: PropTypes.arrayOf(
+      PropTypes.shape({
+        description: PropTypes.string,
+        isHidden: PropTypes.bool,
+        regions: PropTypes.shape(),
+        name: PropTypes.string,
+      }),
+    ).isRequired,
     layerId: PropTypes.string,
     isEditing: PropTypes.bool.isRequired,
     isShared: PropTypes.bool.isRequired,
@@ -41,7 +43,6 @@ export default class LayerSidebar extends Component {
   };
 
   static defaultProps = {
-    layer: null,
     layerId: null,
     regionForm: null,
     colorPicker: null,
@@ -52,10 +53,11 @@ export default class LayerSidebar extends Component {
   };
 
   onRenderContent = () => {
-    const { colorPicker, updateRegion, layer } = this.props;
+    const { colorPicker, updateRegion, layers } = this.props;
     if (!colorPicker) {
       return null;
     }
+
     return (
       <div className="LayerSidebar-ColorHint--content">
         <CompactPicker
@@ -63,7 +65,7 @@ export default class LayerSidebar extends Component {
           onChangeComplete={({ hex }) =>
             updateRegion(colorPicker, { color: hex })
           }
-          color={layer.regions[colorPicker].color}
+          color={layers[0].regions[colorPicker].color}
         />
       </div>
     );
@@ -74,8 +76,8 @@ export default class LayerSidebar extends Component {
   };
 
   renderHidden() {
-    const { layer } = this.props;
-    if (!layer.isHidden) {
+    const { layers } = this.props;
+    if (!layers[0].isHidden) {
       return null;
     }
     return (
@@ -83,15 +85,15 @@ export default class LayerSidebar extends Component {
         <EyeOff size={18} />
         <FormattedMessage
           id="misc.layerHidden"
-          values={{ entity: layer.name }}
+          values={{ entity: layers[0].name }}
         />
       </FlexContainer>
     );
   }
 
   renderDescription() {
-    const { layer } = this.props;
-    if (!layer.description) {
+    const { layers } = this.props;
+    if (!layers[0].description) {
       return null;
     }
     return (
@@ -102,7 +104,7 @@ export default class LayerSidebar extends Component {
         <span className="LayerSidebar-Label">
           <FormattedMessage id="misc.description" />
         </span>
-        <p className="LayerSidebar-Description">{layer.description}</p>
+        <p className="LayerSidebar-Description">{layers[0].description}</p>
       </FlexContainer>
     );
   }
@@ -113,7 +115,7 @@ export default class LayerSidebar extends Component {
       isEditing,
       isShared,
       initializeRegionForm,
-      layer,
+      layers,
       regionForm,
       colorPicker,
       intl,
@@ -141,7 +143,7 @@ export default class LayerSidebar extends Component {
           />
           {newRegion}
           {sortBy(
-            map(layer.regions || {}, (region, regionId) => ({
+            map(layers[0].regions || {}, (region, regionId) => ({
               ...region,
               sort: region.name.toLowerCase(),
               regionId,

--- a/src/store/actions/entity.actions.js
+++ b/src/store/actions/entity.actions.js
@@ -22,7 +22,6 @@ import {
   getCurrentEntity,
   getCurrentSector,
 } from 'store/selectors/entity.selectors';
-import { currentSectorLayers } from 'store/selectors/layer.selectors';
 import { isCurrentSectorSaved } from 'store/selectors/sector.selectors';
 
 import {
@@ -347,13 +346,8 @@ export const toggleLayer = layerId => (dispatch, getState) => {
     return Promise.resolve();
   }
 
-  const customLayers = currentSectorLayers(state);
-  let layers = sector.layers || {};
+  const layers = sector.layers || {};
   const layerToggle = layers[layerId] !== undefined && !layers[layerId];
-  layers =
-    customLayers[layerId] && layerToggle
-      ? { ...layers, ...mapValues(customLayers, () => false) }
-      : layers;
 
   const sectorUpdate = {
     layers: {


### PR DESCRIPTION
## Description

Outside of the navigation layer, custom layers could only be shown one at a time. This change allows any number of custom layers to be shown at once. The hover tooltips will show the active regions of any layer within a given hex.

<img width="1171" alt="Screen Shot 2019-07-31 at 9 16 00 AM" src="https://user-images.githubusercontent.com/3017491/62219613-419e9180-b374-11e9-84aa-4804f50bd961.png">

Resolves #220 