### PR TITLE
Translate Entity Attributes in JSON Export

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,4 +1,12 @@
 {
+  "7.12.0": {
+    "description": "Translate entity attributes in JSON export.",
+    "date": "8-10-2019",
+    "changes": [
+      "Cut out unnecessary parts of the JSON export.",
+      "Ensure hidden items are filtered from players."
+    ]
+  },
   "7.11.0": {
     "description": "Add image option to faction entities.",
     "date": "8-10-2019"

--- a/src/components/export-modal/export-modal.js
+++ b/src/components/export-modal/export-modal.js
@@ -7,7 +7,7 @@ import Modal from 'primitives/modal/modal';
 import Button from 'primitives/other/button';
 import ExportTypes from 'constants/export-types';
 import { createJSONDownload, createImageDownlaod } from 'utils/export';
-import { mapValues, omit } from 'constants/lodash';
+import { translateEntities } from 'utils/entity';
 
 import './style.scss';
 
@@ -24,12 +24,7 @@ export default function ExportModal({
   const onContinue = () => {
     if (exportType === ExportTypes.json.key) {
       closeExport();
-      return createJSONDownload(
-        mapValues(entities, entityTypes =>
-          mapValues(entityTypes, entity => omit(entity, 'sector')),
-        ),
-        sector.name,
-      );
+      return createJSONDownload(translateEntities(entities, intl), sector.name);
     }
     if (exportType === ExportTypes.image.key) {
       closeExport();

--- a/src/components/export-modal/index.js
+++ b/src/components/export-modal/index.js
@@ -7,7 +7,7 @@ import {
   isExportOpenSelector,
 } from 'store/selectors/base.selectors';
 import {
-  getCurrentEntities,
+  getExportEntities,
   getCurrentSector,
 } from 'store/selectors/entity.selectors';
 import {
@@ -22,7 +22,7 @@ const mapStateToProps = createStructuredSelector({
   exportType: exportTypeSelector,
   isExportOpen: isExportOpenSelector,
   sector: getCurrentSector,
-  entities: getCurrentEntities,
+  entities: getExportEntities,
 });
 
 export default injectIntl(

--- a/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-tags.js
+++ b/src/components/sidebar-entities/default-sidebar/entity-attributes/entity-tags.js
@@ -128,7 +128,7 @@ export default function EntityTags({
         ({ key }) =>
           !isShared || (entity.visibility || {})[`tag.${key}`] !== false,
       )
-      .map(({ key, name, description, ...lists }) => {
+      .map(({ key, name, ...lists }) => {
         let visibility;
         if (!isShared && (entity.visibility || {})[`tag.${key}`] === false) {
           visibility = <LinkIcon icon={EyeOff} size={18} />;

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -136,6 +136,31 @@ export const getCurrentEntities = createDeepEqualSelector(
     ),
 );
 
+export const getExportEntities = createDeepEqualSelector(
+  [getCurrentEntities, isViewingSharedSector],
+  (entities, isShared) =>
+    mapValues(omit(entities, 'settings', 'navigation', 'layer'), entityTypes =>
+      mapValues(entityTypes, entity => ({
+        ...omit(entity, 'sector', 'visibility'),
+        created: entity.created ? entity.created.toDate() : undefined,
+        updated: entity.updated ? entity.updated.toDate() : undefined,
+        attributes: {
+          ...pickBy(entity.attributes, (value, key) => {
+            return (
+              !isShared || !includes(keys(entity.visibility), `attr.${key}`)
+            );
+          }),
+          tags: (entity.attributes || {}).tags
+            ? entity.attributes.tags.filter(
+                tag =>
+                  !isShared || !includes(keys(entity.visibility), `tag.${tag}`),
+              )
+            : undefined,
+        },
+      })),
+    ),
+);
+
 export const getCurrentSector = createDeepEqualSelector(
   [currentSectorSelector, entitySelector],
   (currentSector, entities) => entities[Entities.sector.key][currentSector],

--- a/src/store/selectors/entity.selectors.js
+++ b/src/store/selectors/entity.selectors.js
@@ -145,11 +145,11 @@ export const getExportEntities = createDeepEqualSelector(
         created: entity.created ? entity.created.toDate() : undefined,
         updated: entity.updated ? entity.updated.toDate() : undefined,
         attributes: {
-          ...pickBy(entity.attributes, (value, key) => {
-            return (
-              !isShared || !includes(keys(entity.visibility), `attr.${key}`)
-            );
-          }),
+          ...pickBy(
+            entity.attributes,
+            (value, key) =>
+              !isShared || !includes(keys(entity.visibility), `attr.${key}`),
+          ),
           tags: (entity.attributes || {}).tags
             ? entity.attributes.tags.filter(
                 tag =>


### PR DESCRIPTION
# Description

The JSON export has been largely ignored for quite some time. Entity attributes (situation, occupation, tags, etc.) are now translated and added to the export. Created and updated dates now render as formatted strings instead of seconds/milliseconds. Hidden attributes and tags are now removed from the player export as well.

Resolves https://github.com/mpigsley/sectors-without-number/issues/196