### PR TITLE
Include routes, layers, and factions in JSON export

### DIFF
--- a/src/components/export-modal/export-modal.js
+++ b/src/components/export-modal/export-modal.js
@@ -22,12 +22,20 @@ export default function ExportModal({
   intl,
   entities,
   sector,
+  routes,
+  layers,
+  factions,
 }) {
   const onContinue = () => {
     if (exportType === ExportTypes.json.key) {
       closeExport();
       return createJSONDownload(
-        translateEntities(entities, customTags, intl),
+        {
+          ...translateEntities(entities, customTags, intl),
+          routes,
+          layers,
+          factions,
+        },
         `${sector.name} - ${dayjs().format('MMMM D, YYYY')}`,
       );
     }
@@ -97,4 +105,7 @@ ExportModal.propTypes = {
     name: PropTypes.string,
   }).isRequired,
   entities: PropTypes.shape().isRequired,
+  routes: PropTypes.shape().isRequired,
+  layers: PropTypes.shape().isRequired,
+  factions: PropTypes.shape().isRequired,
 };

--- a/src/components/export-modal/index.js
+++ b/src/components/export-modal/index.js
@@ -6,11 +6,15 @@ import {
   customTagSelector,
   exportTypeSelector,
   isExportOpenSelector,
+  currentSectorSelector,
+  navigationRoutesSelector,
 } from 'store/selectors/base.selectors';
 import {
   getExportEntities,
   getCurrentSector,
 } from 'store/selectors/entity.selectors';
+import { currentSectorLayers } from 'store/selectors/layer.selectors';
+import { currentSectorFactions } from 'store/selectors/faction.selectors';
 import {
   setEntityExport,
   closeExport,
@@ -19,12 +23,18 @@ import {
 
 import ExportModal from './export-modal';
 
+const currentSectorRoutes = state =>
+  navigationRoutesSelector(state)[currentSectorSelector(state)] || {};
+
 const mapStateToProps = createStructuredSelector({
   exportType: exportTypeSelector,
   isExportOpen: isExportOpenSelector,
   customTags: customTagSelector,
   sector: getCurrentSector,
   entities: getExportEntities,
+  routes: currentSectorRoutes,
+  layers: currentSectorLayers,
+  factions: currentSectorFactions,
 });
 
 export default injectIntl(


### PR DESCRIPTION
These subcollections are already loaded into Redux state on sector load but were not included in the export payload. Routes and layers were explicitly omitted from the entity selector; factions were never wired up at all. Merges them into the download object after entity translation to avoid translateEntities crashing on unknown entity types.